### PR TITLE
Refactor conversion of BIRDMAn model to ArviZ InferenceData

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install conda packages
         shell: bash -l {0}
-        run: conda install -c conda-forge dask biom-format patsy pytest xarray scikit-bio flake8 arviz=0.11.1
+        run: conda install -c conda-forge dask biom-format patsy pytest xarray scikit-bio flake8 arviz>=0.11.2
 
       - name: Install BIRDMAn
         shell: bash -l {0}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Install conda packages
         shell: bash -l {0}
-        run: conda install -c conda-forge dask biom-format patsy pytest xarray scikit-bio flake8
+        run: conda install -c conda-forge dask biom-format patsy pytest xarray scikit-bio flake8 arviz=0.11.1
 
       - name: Install BIRDMAn
         shell: bash -l {0}

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -171,7 +171,7 @@ class Model:
         :param dims: Dimensions of parameters in the model
         :type dims: dict
 
-        :param_concatenation_name: Name to aggregate features when combining
+        :param concatenation_name: Name to aggregate features when combining
             multiple fits, defaults to 'feature'
         :type concatentation_name: str, optional
 
@@ -219,4 +219,15 @@ class Model:
         else:
             raise ValueError("Unrecognized fit type!")
 
-        return fit_to_inference(self.fit, **args)
+        inference = fit_to_inference(self.fit, **args)
+        if include_observed_data:
+            obs = az.from_dict(
+                observed_data={"observed": self.dat["y"]},
+                coords={
+                    "sample": self.sample_names,
+                    "feature": self.feature_names
+                },
+                dims={"observed": ["sample", "feature"]}
+            )
+            inference = az.concat(inference, obs)
+        return inference

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 from patsy import dmatrix
 
-from .model_util import single_fit_to_xarray, multiple_fits_to_xarray
+from .model_util import single_fit_to_inference, multiple_fits_to_inference
 
 
 class Model:
@@ -133,61 +133,85 @@ class Model:
         return _fits
 
     def to_inference_object(
-            self,
-            params_to_include: Sequence,
-            feature_names: Sequence = None,
-            covariate_names: Sequence = None,
-            alr_params: Sequence = None,
+        self,
+        params: Sequence[str],
+        coords: dict,
+        dims: dict,
+        alr_params: Sequence[str] = None,
+        include_observed_data: bool = False,
+        posterior_predictive: str = None,
+        log_likelihood: str = None
     ) -> az.InferenceData:
-        """Convert fitted Stan model into arviz InferenceData object.
+        """Convert fitted Stan model into ``arviz`` InferenceData object.
 
-        .. note:: We don't use the arviz from_cmdstanpy function because it
-            does not transform the ALR coordinates and returns all parameters
-            (including irrelevant intermediates).
+        Example for a simple Negative Binomial model:
 
-        :param params_to_include: Names of parameters to keep
-        :type params_to_include: Sequence[str]
+        .. code-block:: python
 
-        :param feature_names: Names of features, defaults to biom table
-            observation ids
-        :type feature_names: Sequence[str]
+            inf_obj = model.to_inference_object(
+                params=['beta', 'phi'],
+                coords={
+                    'features': model.feature_names,
+                    'covariates': model.colnames
+                },
+                dims={
+                    'beta': ['covariates', 'features'],
+                    'phi': ['features']
+                },
+                alr_params=['beta']
+            )
 
-        :param covariate_names: Names of covariates in design matrix, defaults
-            to columns of dmat
-        :type covariate_names: Sequence[str]
+        :param params: Posterior fitted parameters to include
+        :type params: Sequence[str]
 
-        :param alr_params: Parameters to convert from ALR to CLR
-        :type alr_params: Sequence[str]
+        :param coords: Mapping of entries in dims to labels
+        :type coords: dict
 
-        :returns: arviz InferenceData object with selected values/coordinates
+        :param dims: Dimensions of parameters in the model
+        :type dims: dict
+
+        :param alr_params: Parameters to convert from ALR to CLR (this will
+            be ignored if the model has been parallelized across features)
+        :type alr_params: Sequence[str], optional
+
+        :param include_observed_data: Whether to include the original feature
+            table values into the ``arviz`` InferenceData object, default is
+            False
+        :type include_observed_data: bool, optional
+
+        :param posterior_predictive: Name of posterior predictive values from
+            Stan model to include in ``arviz`` InferenceData object
+        :type posterior_predictive: str, optional
+
+        :param log_likelihood: Name of log likelihood values from Stan model
+            to include in ``arviz`` InferenceData object
+        :type log_likelihood: str, optional
+
+        :returns: ``arviz`` InferenceData object with selected values
         :rtype: az.InferenceData
         """
         if self.fit is None:
             raise ValueError("Model has not been fit!")
 
-        if feature_names is None:
-            feature_names = self.table.ids(axis="observation")
-        if covariate_names is None:
-            covariate_names = self.dmat.columns.tolist()
-
         if isinstance(self.fit, CmdStanMCMC):
-            ds = single_fit_to_xarray(
-                fit=self.fit,
-                params=params_to_include,
-                feature_names=feature_names,
-                covariate_names=covariate_names,
-                alr_params=alr_params,
-            )
+            fit_to_inference = single_fit_to_inference
         elif isinstance(self.fit, Sequence):
+            fit_to_inference = multiple_fits_to_inference
+
             if alr_params is not None:
                 warnings.warn("ALR to CLR not performed on parallel models.",
                               UserWarning)
-            ds = multiple_fits_to_xarray(
-                fits=self.fit,
-                params=params_to_include,
-                feature_names=feature_names,
-                covariate_names=covariate_names
-            )
         else:
             raise ValueError("Unrecognized fit type!")
+
+        ds = fit_to_inference(
+            fit=self.fit,
+            params=params,
+            coords=coords,
+            dims=dims,
+            alr_params=alr_params,
+            include_observed_data=include_observed_data,
+            posterior_predictive=posterior_predictive,
+            log_likelihood=log_likelihood
+        )
         return az.convert_to_inference_data(ds)

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -1,10 +1,9 @@
 import re
-from typing import Sequence, Union
+from typing import Sequence
 
 import arviz as az
 from cmdstanpy import CmdStanMCMC
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 from .util import convert_beta_coordinates
@@ -131,6 +130,10 @@ def multiple_fits_to_inference(
         k: [dim for dim in v if dim != concatenation_name]
         for k, v in dims.items()
     }
+
+    # If dims are unchanged it means the concatenation_name was not found
+    if new_dims == dims:
+        raise ValueError("concatenation_name must match dimensions in dims")
 
     po_list = []  # posterior
     ss_list = []  # sample stats

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -1,6 +1,7 @@
-from typing import Sequence
+import re
+from typing import Sequence, Union
 
-# import arviz as az
+import arviz as az
 from cmdstanpy import CmdStanMCMC
 import numpy as np
 import pandas as pd
@@ -9,131 +10,114 @@ import xarray as xr
 from .util import convert_beta_coordinates
 
 
-def single_fit_to_xarray(
+def single_fit_to_inference(
     fit: CmdStanMCMC,
-    params: Sequence,
-    feature_names: Sequence,
-    covariate_names: Sequence,
-    alr_params: Sequence
+    params: Sequence[str],
+    coords: dict,
+    dims: dict,
+    alr_params: Sequence[str] = None,
+    include_observed_data: bool = False,
+    posterior_predictive: str = None,
+    log_likelihood: str = None
 ) -> xr.Dataset:
-    """Convert fitted Stan model into xarray Dataset.
+    """Convert fitted Stan model into inference object.
 
     :param fit: Fitted model
     :type params: CmdStanMCMC
 
-    :param params: Parameters to include in xarray Dataset
+    :param params: Posterior fitted parameters to include
     :type params: Sequence[str]
 
-    :param feature_names: Names of features in feature table
-    :type feature_names: Sequence[str]
+    :param coords: Mapping of entries in dims to labels
+    :type coords: dict
 
-    :param covariate_names: Names of covariates in design matrix
-    :type covariate_names: Sequence[str]
+    :param dims: Dimensions of parameters in the model
+    :type dims: dict
 
-    :param alr_params: Names of parameters to convert from ALR to CLR
-    :type alr_params: Sequence[str]
+    :param alr_params: Parameters to convert from ALR to CLR (this will
+        be ignored if the model has been parallelized across features)
+    :type alr_params: Sequence[str], optional
 
-    :returns: xarray Dataset of chosen parameter draws
-    :rtype: xr.Dataset
+    :param include_observed_data: Whether to include the original feature
+        table values into the ``arviz`` InferenceData object, default is False
+    :type include_observed_data: bool, optional
+
+    :param posterior_predictive: Name of posterior predictive values from
+        Stan model to include in ``arviz`` InferenceData object
+    :type posterior_predictive: str, optional
+
+    :param log_likelihood: Name of log likelihood values from Stan model
+        to include in ``arviz`` InferenceData object
+    :type log_likelihood: str, optional
+
+    :returns: ``arviz`` InferenceData object with selected values
+    :rtype: az.InferenceData
     """
-    data_vars = dict()
-    for param in params:
-        param_draws = fit.stan_variable(param)
-        if param_draws.ndim == 3:  # matrix parameter
-            if param in alr_params:
-                param_draws = convert_beta_coordinates(param_draws)
-
-            # Split parameters into individual chains
-            # Should be sequential i.e. 0-99 is chain 1, 100-199 is chain 2
-            # Becomes (chains x cov x features x draws)
-            # TODO: Can probably done smarter with np.reshape
-            param_draws = np.array(np.split(param_draws, fit.chains,
-                                            axis=2))
-            param_coords = ["chain", "covariate", "feature", "draw"]
-        elif param_draws.ndim == 2:  # vector parameter
-            param_draws = np.array(np.split(param_draws, fit.chains,
-                                            axis=0))
-            param_coords = ["chain", "draw", "feature"]
-        else:
-            raise ValueError("Incompatible dimensionality!")
-        data_vars[param] = (param_coords, param_draws)
-
-    ds = xr.Dataset(
-        data_vars=data_vars,
-        coords=dict(
-            covariate=covariate_names,
-            feature=feature_names,
-            draw=np.arange(fit.num_draws_sampling),
-            chain=np.arange(fit.chains)
-        )
+    # remove alr params so initial dim fitting works
+    new_dims = {k: v for k, v in dims.items() if k not in alr_params}
+    inference = az.from_cmdstanpy(
+        posterior=fit,
+        posterior_predictive=posterior_predictive,
+        log_likelihood=log_likelihood,
+        coords=coords,
+        dims=new_dims
     )
-    ds = ds.transpose("covariate", "feature", "chain", "draw")
-    return ds
+
+    vars_to_drop = set(inference.posterior.data_vars).difference(params)
+    inference.posterior = _drop_data(inference.posterior, vars_to_drop)
+
+    for param in alr_params:
+        # want to run on each chain independently
+        all_chain_clr_coords = []
+        for i in np.arange(fit.chains):
+            chain_alr_coords = inference.posterior[param].sel(chain=i)
+            chain_clr_coords = convert_beta_coordinates(chain_alr_coords)
+            all_chain_clr_coords.append(chain_clr_coords)
+        all_chain_clr_coords = np.array(all_chain_clr_coords)
+        # chain x draw x covariate x feature
+
+        tmp_dims = ["chain", "draw"] + dims[param]
+        chain_coords = {"chain": np.arange(fit.chains)}
+        draw_coords = {"draw": np.arange(fit.num_draws_sampling)}
+        param_da = xr.DataArray(
+            all_chain_clr_coords,
+            dims=tmp_dims,
+            coords={**coords, **chain_coords, **draw_coords}
+        )
+
+        inference.posterior[param] = param_da
+
+        # For now assume that beta dimensionality is 2D
+        inference.posterior = inference.posterior.drop_dims(
+            [f"{param}_dim_{i}" for i in range(2)]
+        )
+    return inference
 
 
-def multiple_fits_to_xarray(
+def multiple_fits_to_inference(
     fits: Sequence[CmdStanMCMC],
-    params: Sequence,
-    feature_names: Sequence,
-    covariate_names: Sequence
+    params: Union[dict, Sequence],
 ) -> xr.Dataset:
     """Save fitted parameters to xarray DataSet for multiple fits.
 
     :param fits: Fitted models for each feature
     :type params: Sequence[CmdStanMCMC]
-
-    :param params: Parameters to include in xarray Dataset
-    :type params: Sequence[str]
-
-    :param feature_names: Names of features in feature table
-    :type feature_names: Sequence[str]
-
-    :param covariate_names: Names of covariates in design matrix
-    :type covariate_names: Sequence[str]
-
-    :returns: xarray Dataset of chosen parameter draws
-    :rtype: xr.Dataset
     """
-    assert len(feature_names) == len(fits)
 
-    _fit = fits[0]
-    draw_range = np.arange(_fit.num_draws_sampling)
-    chain_range = np.arange(_fit.chains)
-    param_da_list = []
-    # Outer for loop creates DataArray for each parameter
-    for param in params:
-        all_feat_param_da_list = []
-        # Inner for loop creates list of DataArrays for each feature
-        for feat, fit in zip(feature_names, fits):
-            param_draws = fit.stan_variable(param)  # draw x cov
+    return
 
-            param_draws = np.array(np.split(param_draws, fit.chains,
-                                            axis=0))
-            if param_draws.ndim == 3:  # matrix parameter (chain x draw x cov)
-                # not sure if we have to CLR...
-                dims = ["chain", "draw", "covariate"]
-                coords = [chain_range, draw_range, covariate_names]
-            elif param_draws.ndim == 2:  # vector parameter (chain x draw)
-                dims = ["chain", "draw"]
-                coords = [chain_range, draw_range]
-            else:
-                raise ValueError("Incompatible dimensionality!")
-            feat_param_da = xr.DataArray(  # single feat-param da
-                param_draws,
-                coords=coords,
-                dims=dims,
-                name=param,
-            )
-            all_feat_param_da_list.append(feat_param_da)
 
-        # Concatenates all features for a given parameter to a DataArray
-        all_feat_param_da = xr.concat(
-            all_feat_param_da_list,
-            pd.Index(feature_names, name="feature"),
-        )
-        param_da_list.append(all_feat_param_da)
-
-    # Merges individual DataArrays for each parameter
-    ds = xr.merge(param_da_list)
-    ds = ds.transpose("covariate", "feature", "chain", "draw")
-    return ds
+def _drop_data(
+    dataset: xr.Dataset,
+    vars_to_drop: Sequence
+) -> xr.Dataset:
+    """Drop data and associated dimensions from inference group."""
+    new_dataset = dataset.drop_vars(vars_to_drop)
+    # TODO: Figure out how to do this more cleanly
+    dims_to_drop = []
+    for var in vars_to_drop:
+        for dim in new_dataset.dims:
+            if re.match(f"{var}_dim_\\d", dim):
+                dims_to_drop.append(dim)
+    new_dataset = new_dataset.drop_dims(dims_to_drop)
+    return new_dataset

--- a/birdman/templates/negative_binomial.stan
+++ b/birdman/templates/negative_binomial.stan
@@ -18,7 +18,6 @@ parameters {
 transformed parameters {
   matrix[N, D-1] lam;
   matrix[N, D] lam_clr;
-  matrix[N, D] prob;
   vector[N] z;
   vector<lower=0>[D] phi;
 
@@ -51,10 +50,12 @@ model {
 
 generated quantities {
   matrix[N, D] y_predict;
+  matrix[N, D] log_lik;
 
   for (n in 1:N){
     for (i in 1:D){
       y_predict[n, i] = neg_binomial_2_log_rng(depth[n] + lam_clr[n, i], phi[i]);
+      log_lik[n, i] = neg_binomial_2_log_lpmf(y[n, i] | depth[n] + lam_clr[n, i], phi[i]);
     }
   }
 }

--- a/birdman/util.py
+++ b/birdman/util.py
@@ -24,16 +24,16 @@ def convert_beta_coordinates(beta: np.ndarray) -> np.ndarray:
         d features)
     :type beta: np.ndarray
 
-    :returns: Matrix of beta CLR coordinates (p covariates x (d+1) features x
-        n draws)
+    :returns: Matrix of beta CLR coordinates (n draws x p covariates x d+1
+        features)
     :rtype: np.ndarray
     """
     # axis moving is an artifact of previous PyStan implementation
     # want dims to be (p covariates x d features x n draws)
     # TODO: make this function work on the original dimensions
-    beta = np.moveaxis(beta, [1, 2, 0], [0, 1, 2])
-    num_covariates, num_features, num_draws = beta.shape
-    beta_clr = np.zeros((num_covariates, num_features+1, num_draws))
+    num_draws, num_covariates, num_features = beta.shape
+    beta_clr = np.zeros((num_draws, num_covariates, num_features+1))
     for i in range(num_covariates):  # TODO: vectorize
-        beta_clr[i, :, :] = alr_to_clr(beta[i, :, :])
+        beta_slice = beta[:, i, :].T  # features x draws
+        beta_clr[:, i, :] = alr_to_clr(beta_slice).T
     return beta_clr

--- a/birdman/util.py
+++ b/birdman/util.py
@@ -28,9 +28,6 @@ def convert_beta_coordinates(beta: np.ndarray) -> np.ndarray:
         features)
     :rtype: np.ndarray
     """
-    # axis moving is an artifact of previous PyStan implementation
-    # want dims to be (p covariates x d features x n draws)
-    # TODO: make this function work on the original dimensions
     num_draws, num_covariates, num_features = beta.shape
     beta_clr = np.zeros((num_draws, num_covariates, num_features+1))
     for i in range(num_covariates):  # TODO: vectorize

--- a/environment.yml
+++ b/environment.yml
@@ -12,4 +12,5 @@ dependencies:
   - patsy
   - dask
   - biom-format
-prefix: /Users/gibs/miniconda3/envs/test
+  - arviz
+prefix: /Users/gibs/miniconda3/envs/birdman

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "biom-format",
         "patsy",
         "xarray",
-        "arviz"
+        "arviz==0.11.2"
     ],
     extras_require={"dev": ["pytest", "scikit-bio"]}
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "biom-format",
         "patsy",
         "xarray",
-        "arviz==0.11.2"
+        "arviz>=0.11.2"
     ],
     extras_require={"dev": ["pytest", "scikit-bio"]}
 )

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -29,15 +29,23 @@ def test_custom_model(table_biom, metadata):
     custom_model.fit_model()
 
     inference = custom_model.to_inference_object(
-        params_to_include=["beta_var"],
+        params=["beta_var"],
+        coords={
+            "feature": custom_model.feature_names,
+            "covariate": custom_model.colnames
+        },
+        dims={
+            "beta_var": ["covariate", "feature"],
+            "phi": ["feature"]
+        },
         alr_params=["beta_var"]
     )
 
-    assert inference.groups() == ["posterior"]
+    assert set(inference.groups()) == {"posterior", "sample_stats"}
     ds = inference.posterior
 
     assert ds.coords._names == {"chain", "covariate", "draw", "feature"}
-    assert ds["beta_var"].shape == (2, 28, 4, 100)
+    assert set(ds["beta_var"].shape) == {2, 28, 4, 100}
 
     exp_feature_names = table_biom.ids(axis="observation")
     ds_feature_names = ds.coords["feature"]

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 import os
 from pkg_resources import resource_filename
 
+import numpy as np
 import pytest
 
 from birdman import NegativeBinomial
@@ -59,6 +60,30 @@ class TestToInference:
         target_groups = {"posterior", "sample_stats", "log_likelihood",
                          "posterior_predictive"}
         assert set(inference_data.groups()) == target_groups
+
+    def test_serial_to_inference_obs(self, example_model):
+        inference_data = example_model.to_inference_object(
+            params=["beta", "phi"],
+            coords={
+                "feature": example_model.feature_names,
+                "covariate": example_model.colnames
+            },
+            dims={
+                "beta": ["covariate", "feature"],
+                "phi": ["feature"]
+            },
+            alr_params=["beta"],
+            log_likelihood="log_lik",
+            posterior_predictive="y_predict",
+            include_observed_data=True
+        )
+        target_groups = {"posterior", "sample_stats", "log_likelihood",
+                         "posterior_predictive", "observed_data"}
+        assert set(inference_data.groups()) == target_groups
+        np.testing.assert_array_equal(
+            inference_data.observed_data["observed"],
+            example_model.dat["y"]
+        )
 
     def test_parallel_to_inference(self, example_parallel_model):
         inference_data = example_parallel_model.to_inference_object(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,7 +1,6 @@
 import os
 from pkg_resources import resource_filename
 
-import numpy as np
 import pytest
 
 from birdman import NegativeBinomial
@@ -42,54 +41,57 @@ class TestModelFit:
 
 
 class TestToInference:
-    # This is the same as in test_model_util
-    # TODO: Create auxillary file to hold this and other utility functions
-    def dataset_comparison(self, model, ds):
-        coord_names = ds.coords._names
-        assert coord_names == {"feature", "draw", "covariate", "chain"}
-        assert ds["beta"].shape == (2, 28, 4, 100)
-        assert ds["phi"].shape == (28, 4, 100)
-
-        exp_feature_names = model.table.ids(axis="observation")
-        ds_feature_names = ds.coords["feature"]
-        assert (exp_feature_names == ds_feature_names).all()
-
-        exp_coord_names = [
-            "Intercept",
-            "host_common_name[T.long-tailed macaque]"
-        ]
-        ds_coord_names = ds.coords["covariate"]
-        assert (exp_coord_names == ds_coord_names).all()
-
-        assert (ds.coords["draw"] == np.arange(100)).all()
-        assert (ds.coords["chain"] == [0, 1, 2, 3]).all()
-
     def test_serial_to_inference(self, example_model):
         inference_data = example_model.to_inference_object(
-            params_to_include=["beta", "phi"],
+            params=["beta", "phi"],
+            coords={
+                "feature": example_model.feature_names,
+                "covariate": example_model.colnames
+            },
+            dims={
+                "beta": ["covariate", "feature"],
+                "phi": ["feature"]
+            },
             alr_params=["beta"],
+            log_likelihood="log_lik",
+            posterior_predictive="y_predict"
         )
-        assert inference_data.groups() == ["posterior"]
-        self.dataset_comparison(example_model, inference_data.posterior)
+        target_groups = {"posterior", "sample_stats", "log_likelihood",
+                         "posterior_predictive"}
+        assert set(inference_data.groups()) == target_groups
 
     def test_parallel_to_inference(self, example_parallel_model):
         inference_data = example_parallel_model.to_inference_object(
-            params_to_include=["beta", "phi"],
+            params=["beta", "phi"],
+            coords={
+                "feature": example_parallel_model.feature_names,
+                "covariate": example_parallel_model.colnames
+            },
+            dims={
+                "beta": ["covariate", "feature"],
+                "phi": ["feature"]
+            },
         )
-        assert inference_data.groups() == ["posterior"]
-        self.dataset_comparison(example_parallel_model,
-                                inference_data.posterior)
+        target_groups = {"posterior", "sample_stats"}
+        assert set(inference_data.groups()) == target_groups
 
     def test_parallel_to_inference_alr_to_clr(self, example_parallel_model):
         with pytest.warns(UserWarning) as w:
             inference_data = example_parallel_model.to_inference_object(
-                params_to_include=["beta", "phi"],
-                alr_params=["beta"],
+                params=["beta", "phi"],
+                coords={
+                    "feature": example_parallel_model.feature_names,
+                    "covariate": example_parallel_model.colnames
+                },
+                dims={
+                    "beta": ["covariate", "feature"],
+                    "phi": ["feature"]
+                },
+                alr_params=["beta"]
             )
 
         assert w[0].message.args[0] == (
             "ALR to CLR not performed on parallel models."
         )
-        assert inference_data.groups() == ["posterior"]
-        self.dataset_comparison(example_parallel_model,
-                                inference_data.posterior)
+        target_groups = {"posterior", "sample_stats"}
+        assert set(inference_data.groups()) == target_groups

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -1,14 +1,15 @@
 import numpy as np
+import pytest
 
 from birdman import model_util as mu
 
 
-class TestToXArray:
+class TestToInference:
     def dataset_comparison(self, model, ds):
         coord_names = ds.coords._names
         assert coord_names == {"feature", "draw", "covariate", "chain"}
-        assert ds["beta"].shape == (2, 28, 4, 100)
-        assert ds["phi"].shape == (28, 4, 100)
+        assert set(ds["beta"].shape) == {2, 28, 4, 100}
+        assert set(ds["phi"].shape) == {28, 4, 100}
 
         exp_feature_names = model.table.ids(axis="observation")
         ds_feature_names = ds.coords["feature"]
@@ -24,21 +25,52 @@ class TestToXArray:
         assert (ds.coords["draw"] == np.arange(100)).all()
         assert (ds.coords["chain"] == [0, 1, 2, 3]).all()
 
-    def test_serial_to_xarray(self, example_model):
-        ds = mu.single_fit_to_xarray(
+    def test_serial_to_inference(self, example_model):
+        inf = mu.single_fit_to_inference(
             fit=example_model.fit,
+            coords={
+                "feature": example_model.feature_names,
+                "covariate": example_model.colnames
+            },
+            dims={
+                "beta": ["covariate", "feature"],
+                "phi": ["feature"]
+            },
             params=["beta", "phi"],
-            covariate_names=example_model.dmat.columns.tolist(),
-            feature_names=example_model.table.ids(axis="observation"),
             alr_params=["beta"]
         )
-        self.dataset_comparison(example_model, ds)
+        self.dataset_comparison(example_model, inf.posterior)
 
-    def test_parallel_to_xarray(self, example_parallel_model):
-        ds = mu.multiple_fits_to_xarray(
+    def test_parallel_to_inference(self, example_parallel_model):
+        inf = mu.multiple_fits_to_inference(
             fits=example_parallel_model.fit,
             params=["beta", "phi"],
-            covariate_names=example_parallel_model.dmat.columns.tolist(),
-            feature_names=example_parallel_model.table.ids(axis="observation")
+            coords={
+                "feature": example_parallel_model.feature_names,
+                "covariate": example_parallel_model.colnames
+            },
+            dims={
+                "beta": ["covariate", "feature"],
+                "phi": ["feature"]
+            },
+            concatenation_name="feature"
         )
-        self.dataset_comparison(example_parallel_model, ds)
+        self.dataset_comparison(example_parallel_model, inf.posterior)
+
+    def test_parallel_to_inference_wrong_concat(self, example_parallel_model):
+        with pytest.raises(ValueError) as excinfo:
+            mu.multiple_fits_to_inference(
+                fits=example_parallel_model.fit,
+                params=["beta", "phi"],
+                coords={
+                    "feature": example_parallel_model.feature_names,
+                    "covariate": example_parallel_model.colnames
+                },
+                dims={
+                    "beta": ["covariate", "feature"],
+                    "phi": ["feature"]
+                },
+                concatenation_name="mewtwo"
+            )
+        assert str(excinfo.value) == ("concatenation_name must match "
+                                      "dimensions in dims")

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -35,14 +35,11 @@ def test_convert_beta_coordinates():
         [0.4, 0.4, 0.1, 0.1],
         [0.1, 0.1, 0.1, 0.7]
     ])
-    # 4 covariates x (4-1) features x 2 draws
-    alr_coords = np.dstack([alr(draw1), alr(draw2)])
-    # 2 draws x 4 covariates x (4-1) features
-    alr_coords = np.moveaxis(alr_coords, [2, 0, 1], [0, 1, 2])
-    clr_coords = util.convert_beta_coordinates(alr_coords)  # p x (d+1) x n
-    exp_coords = np.dstack([clr(draw1), clr(draw2)])
+    alr_coords = np.stack([alr(draw1), alr(draw2)])  # 2 x 4 x 3
+    clr_coords = util.convert_beta_coordinates(alr_coords)  # 2 x 4 x 4
+    exp_coords = np.stack([clr(draw1), clr(draw2)])
     np.testing.assert_array_almost_equal(clr_coords, exp_coords)
 
-    clr_coords_sums = clr_coords.sum(axis=1)
-    exp_clr_coords_sums = np.zeros((4, 2))
+    clr_coords_sums = clr_coords.sum(axis=2)
+    exp_clr_coords_sums = np.zeros((2, 4))
     np.testing.assert_array_almost_equal(exp_clr_coords_sums, clr_coords_sums)


### PR DESCRIPTION
Previous method was hacky and unmaintainable. New implementation makes use of `arviz.from_cmdstanpy` to clean up a lot of the work that was previously done manually.

Also can now specify `log_likelihood`, `posterior_predictive`, & `observed_data` as groups. `sample_stats` is also included by default.

Finally, hook into `arviz`/`xarray` coordinates & dimensions system for annotation. This may require more documentation as it is not super straightforward. It does, however, match `xarray` so it's better in the long run than something novel.