### PR TITLE
Update posterior predictive & log likelihood import (+ misc changes)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,11 @@ jobs:
 
       - name: Install conda packages
         shell: bash -l {0}
-        run: conda install -c conda-forge dask biom-format patsy pytest xarray scikit-bio flake8 arviz>=0.11.2
+        run: conda install -c conda-forge dask biom-format patsy pytest xarray scikit-bio flake8
+
+      - name: Install master branch of arviz
+        shell: bash -l {0}
+        run: pip install git+git://github.com/arviz-devs/arviz.git
 
       - name: Install BIRDMAn
         shell: bash -l {0}

--- a/birdman/diagnostics.py
+++ b/birdman/diagnostics.py
@@ -49,3 +49,12 @@ def rhat(
     :param kwargs: Keyword arguments to pass to ``az.rhat``
     """
     return az.rhat(inference_object, var_names=params, **kwargs)
+
+
+# z.to_stacked_array("g", sample_dims=["chain", "draw"]).shape
+def loo(
+    inference_object: az.InferenceData,
+    **kwargs
+):
+
+    return

--- a/birdman/diagnostics.py
+++ b/birdman/diagnostics.py
@@ -49,12 +49,3 @@ def rhat(
     :param kwargs: Keyword arguments to pass to ``az.rhat``
     """
     return az.rhat(inference_object, var_names=params, **kwargs)
-
-
-# z.to_stacked_array("g", sample_dims=["chain", "draw"]).shape
-def loo(
-    inference_object: az.InferenceData,
-    **kwargs
-):
-
-    return

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -206,7 +206,7 @@ class Model:
             "dims": dims,
             "posterior_predictive": posterior_predictive,
             "log_likelihood": log_likelihood,
-            "sample_names": self.sample_names
+            "sample_names": self.sample_names,
         }
         if isinstance(self.fit, CmdStanMCMC):
             fit_to_inference = single_fit_to_inference
@@ -214,6 +214,7 @@ class Model:
         elif isinstance(self.fit, Sequence):
             fit_to_inference = multiple_fits_to_inference
             args["concatenation_name"] = concatenation_name
+            args["feature_names"] = self.feature_names
             # TODO: Check that dims and concatenation_match
 
             if alr_params is not None:

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -206,6 +206,7 @@ class Model:
             "dims": dims,
             "posterior_predictive": posterior_predictive,
             "log_likelihood": log_likelihood,
+            "sample_names": self.sample_names
         }
         if isinstance(self.fit, CmdStanMCMC):
             fit_to_inference = single_fit_to_inference

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -45,6 +45,9 @@ def single_fit_to_inference(
         to include in ``arviz`` InferenceData object
     :type log_likelihood: str, optional
 
+    :param sample_names: Sample names to label PP and/or LL
+    :type sample_names: Sequence[str]
+
     :returns: ``arviz`` InferenceData object with selected values
     :rtype: az.InferenceData
     """
@@ -113,10 +116,10 @@ def multiple_fits_to_inference(
     coords: dict,
     dims: dict,
     concatenation_name: str,
+    feature_names: Sequence[str],
     posterior_predictive: str = None,
     log_likelihood: str = None,
     sample_names: Sequence[str] = None,
-    feature_names: Sequence[str] = None
 ) -> az.InferenceData:
     """Save fitted parameters to xarray DataSet for multiple fits.
 
@@ -144,8 +147,11 @@ def multiple_fits_to_inference(
         to include in ``arviz`` InferenceData object
     :type log_likelihood: str, optional
 
-    :param sample_names: Names of table samples
-    :type sample_names: Sequence[str], optional
+    :param sample_names: Sample names to label PP and/or LL
+    :type sample_names: Sequence[str]
+
+    :param feature_names: Feature names to label concatenation
+    :type feature_name: Sequence[str]
 
     :returns: ``arviz`` InferenceData object with selected values
     :rtype: az.InferenceData
@@ -229,7 +235,7 @@ def _concat_table_draws(
     da_list: Sequence[xr.DataArray],
     sample_names: Sequence[str],
     concatenation_name: str
-):
+) -> xr.Dataset:
     """For posterior predictive & log likelihood."""
     ds = xr.concat(da_list, concatenation_name)
     dim_name = f"{group}_dim_0"

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -16,7 +16,8 @@ def single_fit_to_inference(
     dims: dict,
     alr_params: Sequence[str] = None,
     posterior_predictive: str = None,
-    log_likelihood: str = None
+    log_likelihood: str = None,
+    sample_names: Sequence[str] = None,
 ) -> xr.Dataset:
     """Convert fitted Stan model into inference object.
 
@@ -51,9 +52,9 @@ def single_fit_to_inference(
     new_dims = {k: v for k, v in dims.items() if k not in alr_params}
     inference = az.from_cmdstanpy(
         posterior=fit,
-        posterior_predictive=posterior_predictive,
-        log_likelihood=log_likelihood,
         coords=coords,
+        log_likelihood=log_likelihood,
+        posterior_predictive=posterior_predictive,
         dims=new_dims
     )
 
@@ -64,7 +65,8 @@ def single_fit_to_inference(
     for param in alr_params:
         # Want to run on each chain independently
         all_chain_clr_coords = []
-        all_chain_alr_coords = np.split(fit.stan_variable(param), 4, axis=0)
+        all_chain_alr_coords = np.split(fit.stan_variable(param), fit.chains,
+                                        axis=0)
         for i, chain_alr_coords in enumerate(all_chain_alr_coords):
             # arviz 0.11.2 seems to flatten for some reason even though
             # the PR was specifically supposed to do the opposite.
@@ -100,7 +102,8 @@ def multiple_fits_to_inference(
     dims: dict,
     concatenation_name: str,
     posterior_predictive: str = None,
-    log_likelihood: str = None
+    log_likelihood: str = None,
+    sample_names: Sequence[str] = None
 ) -> az.InferenceData:
     """Save fitted parameters to xarray DataSet for multiple fits.
 
@@ -127,6 +130,9 @@ def multiple_fits_to_inference(
     :param log_likelihood: Name of log likelihood values from Stan model
         to include in ``arviz`` InferenceData object
     :type log_likelihood: str, optional
+
+    :param sample_names: Names of table samples
+    :type sample_names: Sequence[str], optional
 
     :returns: ``arviz`` InferenceData object with selected values
     :rtype: az.InferenceData
@@ -166,17 +172,38 @@ def multiple_fits_to_inference(
     po_ds = xr.concat(po_list, concatenation_name)
     ss_ds = xr.concat(ss_list, concatenation_name)
     group_dict = {"posterior": po_ds, "sample_stats": ss_ds}
+
+    # Flatten table values for use in arviz built-in stats
     if log_likelihood is not None:
-        group_dict["log_likelihood"] = xr.concat(ll_list, concatenation_name)
+        ll_ds = xr.concat(ll_list, concatenation_name)
+        ll_data = ll_ds[log_likelihood].values
+        ll_ds = ll_ds.drop_vars([log_likelihood])  # drop to save mem
+        ll_data = ll_data.reshape(fit.chains, fit.num_draws_sampling, -1)
+        ll_ds = ll_ds.assign_coords(table_entry=np.arange(ll_data.shape[-1]))
+        ll_ds[log_likelihood] = (("chain", "draw", "table_entry"),
+                                 ll_data)
+        ll_dim_name = f"{log_likelihood}_dim_0"
+        ll_ds = ll_ds.drop_dims([ll_dim_name])
+        group_dict["log_likelihood"] = ll_ds
     if posterior_predictive is not None:
-        group_dict["posterior_predictive"] = xr.concat(pp_list,
-                                                       concatenation_name)
+        pp_ds = xr.concat(pp_list, concatenation_name)
+        pp_data = pp_ds[posterior_predictive].values
+        pp_ds = pp_ds.drop_vars([posterior_predictive])  # drop to save mem
+        pp_data = pp_data.reshape(fit.chains, fit.num_draws_sampling, -1)
+        pp_ds = pp_ds.assign_coords(table_entry=np.arange(pp_data.shape[-1]))
+        pp_ds[posterior_predictive] = (("chain", "draw", "table_entry"),
+                                       pp_data)
+        pp_dim_name = f"{posterior_predictive}_dim_0"
+        pp_ds = pp_ds.drop_dims([pp_dim_name])
+        group_dict["posterior_predictive"] = pp_ds
 
     all_group_inferences = []
     for group in group_dict:
+        # Set concatenation dim coords
         group_ds = group_dict[group].assign_coords(
             {concatenation_name: coords[concatenation_name]}
         )
+
         group_inf = az.InferenceData(**{group: group_ds})  # hacky
         all_group_inferences.append(group_inf)
 

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -52,16 +52,19 @@ def single_fit_to_inference(
     new_dims = {k: v for k, v in dims.items() if k not in alr_params}
 
     extra_dims = dict()
+    extra_coords = dict()
     if log_likelihood is not None:
         extra_dims.update({log_likelihood: ["sample", "feature"]})
+        extra_coords.update({"sample": sample_names})
     if posterior_predictive is not None:
         extra_dims.update({posterior_predictive: ["sample", "feature"]})
+        extra_coords.update({"sample": sample_names})
 
     new_dims.update(extra_dims)
 
     inference = az.from_cmdstanpy(
         posterior=fit,
-        coords=coords,
+        coords={**coords, **extra_coords},
         log_likelihood=log_likelihood,
         posterior_predictive=posterior_predictive,
         dims=new_dims

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ setup(
         "biom-format",
         "patsy",
         "xarray",
-        "arviz>=0.11.2"
+        "arviz @ git+git://github.com/arviz-devs/arviz.git"
+        # Temporary solution until github.com/arviz-devs/arviz/pull/1579
+        # is included in on PyPI
     ],
     extras_require={"dev": ["pytest", "scikit-bio"]}
 )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,4 +1,4 @@
-import birdman.diagostics as diag
+import birdman.diagnostics as diag
 
 
 def test_ess(example_inf, example_parallel_inf):

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -54,7 +54,8 @@ class TestToInference:
                 "beta": ["covariate", "feature"],
                 "phi": ["feature"]
             },
-            concatenation_name="feature"
+            concatenation_name="feature",
+            feature_names=example_parallel_model.feature_names
         )
         self.dataset_comparison(example_parallel_model, inf.posterior)
 
@@ -71,7 +72,8 @@ class TestToInference:
                     "beta": ["covariate", "feature"],
                     "phi": ["feature"]
                 },
-                concatenation_name="mewtwo"
+                concatenation_name="mewtwo",
+                feature_names=example_parallel_model.feature_names
             )
         assert str(excinfo.value) == ("concatenation_name must match "
                                       "dimensions in dims")

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -7,8 +7,8 @@ from birdman import stats
 class TestHotelling:
     def test_hotelling(self):
         p, n = 50, 100  # 50 features, 100 draws
-        Xrand = np.random.randn(p, n)
-        Xreal = np.random.randn(p, n)
+        Xrand = np.random.normal(loc=0, scale=0.1, size=(p, n))
+        Xreal = np.random.normal(loc=0, scale=0.1, size=(p, n))
         Xreal[0, :] += 10  # increment first feature uniformly by 10
 
         _, pval = stats._hotelling(Xrand)


### PR DESCRIPTION
Closes #15 

`arviz` was updated to return N-dimensional values (where N > 1) without flattening - allowing us to more easily import using `arviz.from_cmdstanpy`.

This version of the package is not yet on PyPI so it's installed from GitHub - need to be updated once it's on PyPI.

Misc changes bundled in.