### PR TITLE
Update log-likelihood & posterior predictive import to inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.hpp
 *.DS_Store
 birdman/templates/negative_binomial
+birdman/templates/multinomial
 birdman/templates/negative_binomial_single
 birdman/templates/negative_binomial_lme
 tests/custom_model

--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -1,6 +1,5 @@
 import os
 from pkg_resources import resource_filename
-from typing import Sequence
 
 import arviz as az
 import biom
@@ -184,7 +183,7 @@ class NegativeBinomialLME(Model):
     :type cauchy_scale: float
 
     :param group_var_prior: Standard deviation for normally distributed prior
-        prior values of group_var, defaults to 1.0
+        values of group_var, defaults to 1.0
     :type group_var_prior: float
     """
     def __init__(
@@ -219,6 +218,38 @@ class NegativeBinomialLME(Model):
             "u_p": group_var_prior
         }
         self.add_parameters(param_dict)
+
+    def to_inference_object(self) -> az.InferenceData:
+        """Convert fitted Stan model into ``arviz`` InferenceData object.
+
+        :returns: ``arviz`` InferenceData object with selected values
+        :rtype: az.InferenceData
+        """
+        dims = {
+            "beta": ["covariate", "feature"],
+            "phi": ["feature"],
+            "subj_int": ["subject", "feature"],
+            "log_lhood": ["tbl_sample", "feature"],
+            "y_predict": ["tbl_sample", "feature"]
+        }
+        coords = {
+            "covariate": self.colnames,
+            "feature": self.feature_names,
+            "tbl_sample": self.sample_names,
+            "subject": self.groups
+        }
+
+        # TODO: May want to allow not passing PP/LL/OD in the future
+        inf = super().to_inference_object(
+            params=["beta", "phi"],
+            dims=dims,
+            coords=coords,
+            posterior_predictive="y_predict",
+            log_likelihood="log_lhood",
+            alr_params=["beta", "subj_int"],
+            include_observed_data=True,
+        )
+        return inf
 
 
 class Multinomial(Model):

--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -228,7 +228,7 @@ class NegativeBinomialLME(Model):
         dims = {
             "beta": ["covariate", "feature"],
             "phi": ["feature"],
-            "subj_int": ["subject", "feature"],
+            "subj_int": ["group", "feature"],
             "log_lhood": ["tbl_sample", "feature"],
             "y_predict": ["tbl_sample", "feature"]
         }
@@ -236,7 +236,7 @@ class NegativeBinomialLME(Model):
             "covariate": self.colnames,
             "feature": self.feature_names,
             "tbl_sample": self.sample_names,
-            "subject": self.groups
+            "group": self.groups
         }
 
         # TODO: May want to allow not passing PP/LL/OD in the future

--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -87,6 +87,7 @@ class NegativeBinomial(Model):
                          seed, parallelize_across)
 
         param_dict = {
+            "depth": np.log(table.sum(axis="sample")),  # sampling depths
             "B_p": beta_prior,
             "phi_s": cauchy_scale
         }
@@ -175,6 +176,7 @@ class NegativeBinomialLME(Model):
         self.groups = np.sort(group_var_series.unique())
 
         param_dict = {
+            "depth": np.log(table.sum(axis="sample")),  # sampling depths
             "B_p": beta_prior,
             "phi_s": cauchy_scale,
             "S": len(group_var_series.unique()),
@@ -237,6 +239,7 @@ class Multinomial(Model):
                          seed, parallelize_across="chains")
 
         param_dict = {
+            "depth": table.sum(axis="sample").astype(int),  # sampling depths
             "B_p": beta_prior,
         }
         self.add_parameters(param_dict)

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -5,7 +5,6 @@ import arviz as az
 import biom
 from cmdstanpy import CmdStanModel, CmdStanMCMC
 import dask
-import numpy as np
 import pandas as pd
 from patsy import dmatrix
 

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -73,7 +73,6 @@ class Model:
             "D": table.shape[0],
             "N": table.shape[1],                        # number of samples
             "p": self.dmat.shape[1],                    # number of covariates
-            "depth": np.log(table.sum(axis="sample")),  # sampling depths
             "x": self.dmat.values,                      # design matrix
         }
 

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -205,7 +205,6 @@ class Model:
             "dims": dims,
             "posterior_predictive": posterior_predictive,
             "log_likelihood": log_likelihood,
-            "sample_names": self.sample_names,
         }
         if isinstance(self.fit, CmdStanMCMC):
             fit_to_inference = single_fit_to_inference
@@ -213,7 +212,6 @@ class Model:
         elif isinstance(self.fit, Sequence):
             fit_to_inference = multiple_fits_to_inference
             args["concatenation_name"] = concatenation_name
-            args["feature_names"] = self.feature_names
             # TODO: Check that dims and concatenation_match
 
             if alr_params is not None:

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -54,20 +54,14 @@ def single_fit_to_inference(
     # remove alr params so initial dim fitting works
     new_dims = {k: v for k, v in dims.items() if k not in alr_params}
 
-    extra_dims = dict()
-    extra_coords = dict()
-    if log_likelihood is not None:
-        extra_dims.update({log_likelihood: ["tbl_sample", "feature"]})
-        extra_coords.update({"tbl_sample": sample_names})
-    if posterior_predictive is not None:
-        extra_dims.update({posterior_predictive: ["tbl_sample", "feature"]})
-        extra_coords.update({"tbl_sample": sample_names})
-
-    new_dims.update(extra_dims)
+    if log_likelihood is not None and log_likelihood not in dims:
+        raise KeyError("Must include dimensions for log-likelihood!")
+    if posterior_predictive is not None and posterior_predictive not in dims:
+        raise KeyError("Must include dimensions for posterior predictive!")
 
     inference = az.from_cmdstanpy(
         posterior=fit,
-        coords={**coords, **extra_coords},
+        coords=coords,
         log_likelihood=log_likelihood,
         posterior_predictive=posterior_predictive,
         dims=new_dims

--- a/birdman/templates/multinomial.stan
+++ b/birdman/templates/multinomial.stan
@@ -2,7 +2,7 @@ data {
   int<lower=0> N;       // number of samples
   int<lower=0> D;       // number of dimensions
   int<lower=0> p;       // number of covariates
-  real depth[N];        // sequencing depths of microbes
+  int depth[N];         // sequencing depths of microbes
   matrix[N, p] x;       // covariate matrix
   int y[N, D];          // observed microbe abundances
   real<lower=0> B_p;    // stdev for Beta Normal prior
@@ -19,9 +19,8 @@ transformed parameters {
   vector[N] z;
   simplex[D] theta[N];
 
-  z = to_vector(rep_array(0, N));
   lam = x * beta;
-  lam_clr = append_col(z, lam);
+  lam_clr = append_col(to_vector(rep_array(0, N)), lam);
   for (n in 1:N){
     theta[n] = softmax(to_vector(lam_clr[n,]));
   }

--- a/birdman/templates/negative_binomial.stan
+++ b/birdman/templates/negative_binomial.stan
@@ -50,12 +50,12 @@ model {
 
 generated quantities {
   matrix[N, D] y_predict;
-  matrix[N, D] log_lik;
+  matrix[N, D] log_lhood;
 
   for (n in 1:N){
     for (i in 1:D){
       y_predict[n, i] = neg_binomial_2_log_rng(depth[n] + lam_clr[n, i], phi[i]);
-      log_lik[n, i] = neg_binomial_2_log_lpmf(y[n, i] | depth[n] + lam_clr[n, i], phi[i]);
+      log_lhood[n, i] = neg_binomial_2_log_lpmf(y[n, i] | depth[n] + lam_clr[n, i], phi[i]);
     }
   }
 }

--- a/birdman/templates/negative_binomial.stan
+++ b/birdman/templates/negative_binomial.stan
@@ -2,7 +2,7 @@ data {
   int<lower=0> N;       // number of samples
   int<lower=0> D;       // number of dimensions
   int<lower=0> p;       // number of covariates
-  real depth[N];        // sequencing depths of microbes
+  real depth[N];        // log sequencing depths of microbes
   matrix[N, p] x;       // covariate matrix
   int y[N, D];          // observed microbe abundances
   real<lower=0> B_p;    // stdev for Beta Normal prior
@@ -18,16 +18,14 @@ parameters {
 transformed parameters {
   matrix[N, D-1] lam;
   matrix[N, D] lam_clr;
-  vector[N] z;
   vector<lower=0>[D] phi;
 
   for (i in 1:D){
     phi[i] = 1. / reciprocal_phi[i];
   }
 
-  z = to_vector(rep_array(0, N));
   lam = x * beta;
-  lam_clr = append_col(z, lam);
+  lam_clr = append_col(to_vector(rep_array(0, N)), lam);
 }
 
 model {

--- a/birdman/templates/negative_binomial_lme.stan
+++ b/birdman/templates/negative_binomial_lme.stan
@@ -58,12 +58,12 @@ model {
 
 generated quantities {
   matrix[N, D] y_predict;
-  matrix[N, D] log_lik;
+  matrix[N, D] log_lhood;
 
   for (n in 1:N){
     for (i in 1:D){
       y_predict[n, i] = neg_binomial_2_log_rng(depth[n] + lam_clr[n, i], phi[i]);
-      log_lik[n, i] = neg_binomial_2_log_lpmf(y[n, i] | depth[n] + lam_clr[n, i], phi[i]);
+      log_lhood[n, i] = neg_binomial_2_log_lpmf(y[n, i] | depth[n] + lam_clr[n, i], phi[i]);
     }
   }
 }

--- a/birdman/templates/negative_binomial_lme.stan
+++ b/birdman/templates/negative_binomial_lme.stan
@@ -3,7 +3,7 @@ data {
   int<lower=0> S;                     // number of groups (subjects)
   int<lower=0> D;                     // number of dimensions
   int<lower=0> p;                     // number of covariates
-  real depth[N];                      // sequencing depths of microbes
+  real depth[N];                      // log sequencing depths of microbes
   matrix[N, p] x;                     // covariate matrix
   int<lower=1, upper=S> subj_ids[N];  // mapping of samples to subject IDs
   int y[N, D];                        // observed microbe abundances

--- a/birdman/templates/negative_binomial_single.stan
+++ b/birdman/templates/negative_binomial_single.stan
@@ -1,7 +1,7 @@
 data {
   int<lower=0> N;       // number of samples
   int<lower=0> p;       // number of covariates
-  real depth[N];        // sequencing depths of microbe
+  real depth[N];        // log sequencing depths of microbe
   matrix[N, p] x;       // covariate matrix
   int y[N];             // observed microbe abundances
   real<lower=0> B_p;    // stdev for Beta Normal prior

--- a/birdman/templates/negative_binomial_single.stan
+++ b/birdman/templates/negative_binomial_single.stan
@@ -35,11 +35,11 @@ model {
 }
 
 generated quantities {
-  vector[N] log_lik;
+  vector[N] log_lhood;
   vector[N] y_predict;
 
   for (n in 1:N){
     y_predict[n] = neg_binomial_2_log_rng(depth[n] + lam[n], phi);
-    log_lik[n] = neg_binomial_2_log_lpmf(y[n] | depth[n] + lam[n], phi);
+    log_lhood[n] = neg_binomial_2_log_lpmf(y[n] | depth[n] + lam[n], phi);
   }
 }

--- a/docs/default_model_example.rst
+++ b/docs/default_model_example.rst
@@ -65,25 +65,9 @@ We then have to compile and fit our model. This is very straightforward in BIRDM
 
 Now we have our parameter estimates which we can use in downstream analyses. Many of BIRDMAn's included analysis & visualization functions take an ``arviz.InferenceData`` object. We provide a simple method to convert your BIRDMAn fit into this data structure.
 
-The ``coords`` & ``dims`` arguments follow the ``xarray`` data structure (as that is what ``arviz`` wraps). In this example we want to keep the fitted ``beta`` and ``phi`` parameters and we annotate the dimensions as ``covariate × feature`` and ``feature`` respectively. We also provide the covariate names and feature names. Next, we specify that we want to include the ``log likelihood`` and ``posterior predictive`` values we calculated while model fitting. These will be useful for diagnostics. We include the observed data (the original counts in the feature table) so we can see how well our model did.
-
 .. code-block:: python
 
-    inference = nb.to_inference_object(
-        params=["beta", "phi"],
-        coords={
-            "feature": nb.feature_names,
-            "covariate": nb.colnames,
-        },
-        dims={
-            "beta": ["covariate", "feature"],
-            "phi": ["feature"],
-        },
-        alr_params=["beta"],
-        posterior_predictive="y_predict",
-        log_likelihood="log_lik",
-        include_observed_data=True
-    )
+    inference = nb.to_inference_object()
 
 Finally, we'll plot the feature differentials and their standard deviations. We specify that we are interested in the ``diet[T.DIO]`` differentials but you can easily plot whichever parameter you like through the combination of the ``parameter`` and ``coord`` arguments.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,39 +84,12 @@ def example_parallel_model():
 @pytest.fixture(scope="session")
 def example_inf():
     nb = model()
-    inference = nb.to_inference_object(
-        params=["beta", "phi"],
-        coords={
-            "feature": nb.feature_names,
-            "covariate": nb.colnames,
-        },
-        dims={
-            "beta": ["covariate", "feature"],
-            "phi": ["feature"],
-        },
-        alr_params=["beta"],
-        posterior_predictive="y_predict",
-        log_likelihood="log_lik",
-        include_observed_data=True
-    )
+    inference = nb.to_inference_object()
     return inference
 
 
 @pytest.fixture(scope="session")
 def example_parallel_inf():
     nb = parallel_model()
-    inference = nb.to_inference_object(
-        params=["beta", "phi"],
-        coords={
-            "feature": nb.feature_names,
-            "covariate": nb.colnames,
-        },
-        dims={
-            "beta": ["covariate", "feature"],
-            "phi": ["feature"],
-        },
-        posterior_predictive="y_predict",
-        log_likelihood="log_lik",
-        include_observed_data=True
-    )
+    inference = nb.to_inference_object()
     return inference

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -22,7 +22,8 @@ def test_custom_model(table_biom, metadata):
         {
             "B_p_1": 2.0,
             "B_p_2": 5.0,
-            "phi_s": 0.2
+            "phi_s": 0.2,
+            "depth": np.log(custom_model.table.sum(axis="sample")),
         }
     )
     custom_model.compile_model()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -17,5 +17,6 @@ def test_r2_score(example_inf, example_parallel_inf):
 
 
 def test_loo(example_inf, example_parallel_inf):
+    print(example_inf)
     diag.loo(example_inf)
     diag.loo(example_parallel_inf)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,6 @@ import os
 from pkg_resources import resource_filename
 
 import numpy as np
-import pytest
 
 from birdman import NegativeBinomial, NegativeBinomialLME
 
@@ -78,80 +77,13 @@ class TestModelFit:
 
 class TestToInference:
     def test_serial_to_inference(self, example_model):
-        inference_data = example_model.to_inference_object(
-            params=["beta", "phi"],
-            coords={
-                "feature": example_model.feature_names,
-                "covariate": example_model.colnames
-            },
-            dims={
-                "beta": ["covariate", "feature"],
-                "phi": ["feature"]
-            },
-            alr_params=["beta"],
-            log_likelihood="log_lik",
-            posterior_predictive="y_predict"
-        )
-        target_groups = {"posterior", "sample_stats", "log_likelihood",
-                         "posterior_predictive"}
-        assert set(inference_data.groups()) == target_groups
-
-    def test_serial_to_inference_obs(self, example_model):
-        inference_data = example_model.to_inference_object(
-            params=["beta", "phi"],
-            coords={
-                "feature": example_model.feature_names,
-                "covariate": example_model.colnames
-            },
-            dims={
-                "beta": ["covariate", "feature"],
-                "phi": ["feature"]
-            },
-            alr_params=["beta"],
-            log_likelihood="log_lik",
-            posterior_predictive="y_predict",
-            include_observed_data=True
-        )
+        inference_data = example_model.to_inference_object()
         target_groups = {"posterior", "sample_stats", "log_likelihood",
                          "posterior_predictive", "observed_data"}
         assert set(inference_data.groups()) == target_groups
-        np.testing.assert_array_equal(
-            inference_data.observed_data["observed"],
-            example_model.dat["y"]
-        )
 
     def test_parallel_to_inference(self, example_parallel_model):
-        inference_data = example_parallel_model.to_inference_object(
-            params=["beta", "phi"],
-            coords={
-                "feature": example_parallel_model.feature_names,
-                "covariate": example_parallel_model.colnames
-            },
-            dims={
-                "beta": ["covariate", "feature"],
-                "phi": ["feature"]
-            },
-        )
-        target_groups = {"posterior", "sample_stats"}
-        assert set(inference_data.groups()) == target_groups
-
-    def test_parallel_to_inference_alr_to_clr(self, example_parallel_model):
-        with pytest.warns(UserWarning) as w:
-            inference_data = example_parallel_model.to_inference_object(
-                params=["beta", "phi"],
-                coords={
-                    "feature": example_parallel_model.feature_names,
-                    "covariate": example_parallel_model.colnames
-                },
-                dims={
-                    "beta": ["covariate", "feature"],
-                    "phi": ["feature"]
-                },
-                alr_params=["beta"]
-            )
-
-        assert w[0].message.args[0] == (
-            "ALR to CLR not performed on parallel models."
-        )
-        target_groups = {"posterior", "sample_stats"}
+        inference_data = example_parallel_model.to_inference_object()
+        target_groups = {"posterior", "sample_stats", "log_likelihood",
+                         "posterior_predictive", "observed_data"}
         assert set(inference_data.groups()) == target_groups

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -54,22 +54,9 @@ class TestModelFit:
         nb_lme.compile_model()
         nb_lme.fit_model()
 
-        inf = nb_lme.to_inference_object(
-            params=["beta", "phi", "subj_int"],
-            coords={
-                "feature": nb_lme.feature_names,
-                "covariate": nb_lme.colnames,
-                "group": nb_lme.groups
-            },
-            dims={
-                "beta": ["covariate", "feature"],
-                "phi": ["feature"],
-                "subj_int": ["group", "feature"]
-            },
-            alr_params=["beta", "subj_int"],
-            include_observed_data=False
-        )
+        inf = nb_lme.to_inference_object()
         post = inf.posterior
+        print(post)
         assert post["subj_int"].dims == ("chain", "draw", "group", "feature")
         assert post["subj_int"].shape == (4, 100, 3, 28)
         assert (post.coords["group"].values == ["G0", "G1", "G2"]).all()

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -32,13 +32,13 @@ class TestToInference:
             coords={
                 "feature": example_model.feature_names,
                 "covariate": example_model.colnames,
-                #"sample": example_model.sample_names
+                "sample": example_model.sample_names
             },
             dims={
                 "beta": ["covariate", "feature"],
                 "phi": ["feature"],
-                #"log_lhood": ["sample", "feature"],
-                #"y_predict": ["sample", "feature"]
+                "log_lhood": ["sample", "feature"],
+                "y_predict": ["sample", "feature"]
             },
             params=["beta", "phi"],
             alr_params=["beta"]

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -8,7 +8,7 @@ from birdman import model_util as mu
 class TestToInference:
     def dataset_comparison(self, model, ds):
         coord_names = ds.coords._names
-        assert coord_names == {"feature", "draw", "covariate", "chain"}
+        assert {"feature", "draw", "covariate", "chain"}.issubset(coord_names)
         assert set(ds["beta"].shape) == {2, 28, 4, 100}
         assert set(ds["phi"].shape) == {28, 4, 100}
 
@@ -32,13 +32,13 @@ class TestToInference:
             coords={
                 "feature": example_model.feature_names,
                 "covariate": example_model.colnames,
-                "sample": example_model.sample_names
+                "tbl_sample": example_model.sample_names
             },
             dims={
                 "beta": ["covariate", "feature"],
                 "phi": ["feature"],
-                "log_lhood": ["sample", "feature"],
-                "y_predict": ["sample", "feature"]
+                "log_lhood": ["tbl_sample", "feature"],
+                "y_predict": ["tbl_sample", "feature"]
             },
             params=["beta", "phi"],
             alr_params=["beta"]

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -37,19 +37,8 @@ class TestPPCPlot:
         viz.plot_posterior_predictive_checks(example_inf)
 
     def test_ppc_no_pp(self, example_model):
-        inference = example_model.to_inference_object(
-            params=["beta", "phi"],
-            coords={
-                "feature": example_model.feature_names,
-                "covariate": example_model.colnames,
-            },
-            dims={
-                "beta": ["covariate", "feature"],
-                "phi": ["feature"],
-            },
-            alr_params=["beta"],
-            include_observed_data=True,
-        )
+        inference = example_model.to_inference_object().copy()
+        delattr(inference, "posterior_predictive")
 
         with pytest.raises(ValueError) as excinfo:
             viz.plot_posterior_predictive_checks(inference)
@@ -58,19 +47,8 @@ class TestPPCPlot:
         assert str(excinfo.value) == exp_msg
 
     def test_ppc_no_obs(self, example_model):
-        inference = example_model.to_inference_object(
-            params=["beta", "phi"],
-            coords={
-                "feature": example_model.feature_names,
-                "covariate": example_model.colnames,
-            },
-            dims={
-                "beta": ["covariate", "feature"],
-                "phi": ["feature"],
-            },
-            alr_params=["beta"],
-            posterior_predictive="y_predict"
-        )
+        inference = example_model.to_inference_object().copy()
+        delattr(inference, "observed_data")
 
         with pytest.raises(ValueError) as excinfo:
             viz.plot_posterior_predictive_checks(inference)


### PR DESCRIPTION
Closes #22

Now log-likelihood and posterior predictive are passed in `to_inference_object`. Also updates some of the default models to make them single function calls.