### PR TITLE
Add HPC support

### DIFF
--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -94,7 +94,7 @@ class NegativeBinomial(Model):
         }
         self.add_parameters(param_dict)
 
-    def to_inference_object(self) -> az.InferenceData:
+    def to_inference_object(self, dask_cluster=None, jobs=4) -> az.InferenceData:
         """Convert fitted Stan model into ``arviz`` InferenceData object.
 
         :returns: ``arviz`` InferenceData object with selected values
@@ -116,6 +116,9 @@ class NegativeBinomial(Model):
         args = dict()
         if self.parallelize_across == "chains":
             args["alr_params"] = ["beta"]
+        else:
+            args["dask_cluster"] = dask_cluster
+            args["jobs"] = jobs
         inf = super().to_inference_object(
             params=["beta", "phi"],
             dims=dims,

--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -94,8 +94,18 @@ class NegativeBinomial(Model):
         }
         self.add_parameters(param_dict)
 
-    def to_inference_object(self, dask_cluster=None, jobs=4) -> az.InferenceData:
+    def to_inference_object(
+        self,
+        dask_cluster=None,
+        jobs=4
+    ) -> az.InferenceData:
         """Convert fitted Stan model into ``arviz`` InferenceData object.
+
+        :param dask_cluster: Dask jobqueue to run parallel jobs (optional)
+        :type dask_cluster: dask_jobqueue
+
+        :param jobs: Number of jobs to run in parallel, defaults to 4
+        :type jobs: int
 
         :returns: ``arviz`` InferenceData object with selected values
         :rtype: az.InferenceData

--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -3,6 +3,7 @@ from pkg_resources import resource_filename
 
 import arviz as az
 import biom
+import dask_jobqueue
 import numpy as np
 import pandas as pd
 
@@ -96,13 +97,13 @@ class NegativeBinomial(Model):
 
     def to_inference_object(
         self,
-        dask_cluster=None,
-        jobs=4
+        dask_cluster: dask_jobqueue.JobQueueCluster = None,
+        jobs: int = 4
     ) -> az.InferenceData:
         """Convert fitted Stan model into ``arviz`` InferenceData object.
 
         :param dask_cluster: Dask jobqueue to run parallel jobs (optional)
-        :type dask_cluster: dask_jobqueue
+        :type dask_cluster: dask_jobqueue.JobQueueCluster, optional
 
         :param jobs: Number of jobs to run in parallel, defaults to 4
         :type jobs: int

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -197,7 +197,9 @@ class Model:
         alr_params: Sequence[str] = None,
         include_observed_data: bool = False,
         posterior_predictive: str = None,
-        log_likelihood: str = None
+        log_likelihood: str = None,
+        dask_cluster: dask_jobqueue.JobQueueCluster = None,
+        jobs: int = 4
     ) -> az.InferenceData:
         """Convert fitted Stan model into ``arviz`` InferenceData object.
 
@@ -248,6 +250,12 @@ class Model:
             to include in ``arviz`` InferenceData object
         :type log_likelihood: str, optional
 
+        :param dask_cluster: Dask jobqueue to run parallel jobs (optional)
+        :type dask_cluster: dask_jobqueue
+
+        :param jobs: Number of jobs to run in parallel, defaults to 4
+        :type jobs: int
+
         :returns: ``arviz`` InferenceData object with selected values
         :rtype: az.InferenceData
         """
@@ -267,6 +275,8 @@ class Model:
         elif isinstance(self.fit, Sequence):
             fit_to_inference = multiple_fits_to_inference
             args["concatenation_name"] = concatenation_name
+            args["dask_cluster"] = dask_cluster
+            args["jobs"] = jobs
             # TODO: Check that dims and concatenation_match
 
             if alr_params is not None:

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -100,12 +100,13 @@ class Model:
             parallelizing across features (optional)
         :type dask_cluster: dask_jobqueue
 
-        :param jobs: Number of jobs to run parallel jobs if parallelizing
-            across features, defaults to 4 (optional)
+        :param jobs: Number of jobs to run in parallel jobs if parallelizing
+            across features, defaults to 4
         :type jobs: int
         """
         if self.parallelize_across == "features":
-            self.fit = self._fit_parallel(sampler_args)
+            self.fit = self._fit_parallel(dask_cluster=dask_cluster, jobs=jobs,
+                                          sampler_args=sampler_args)
         elif self.parallelize_across == "chains":
             if None not in [dask_cluster, jobs]:
                 warnings.warn(
@@ -148,7 +149,7 @@ class Model:
         :param dask_cluster: Dask jobqueue to run parallel jobs (optional)
         :type dask_cluster: dask_jobqueue
 
-        :param jobs: Number of jobs to run parallel jobs, defaults to 4
+        :param jobs: Number of jobs to run parallel in parallel, defaults to 4
         :type jobs: int
 
         :param sampler_args: Additional parameters to pass to CmdStanPy

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -146,7 +146,7 @@ class Model:
             _fits.append(_fit)
 
         futures = dask.persist(*_fits)
-        all_fits = dask.compute(futures)
+        all_fits = dask.compute(futures)[0]
         # Set data back to full table
         self.dat["y"] = self.table.matrix_data.todense().T.astype(int)
         return all_fits

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -144,7 +144,7 @@ def multiple_fits_to_inference(
     :type log_likelihood: str, optional
 
     :param dask_cluster: Dask jobqueue to run parallel jobs (optional)
-    :type dask_cluster: dask_jobqueue
+    :type dask_cluster: dask_jobqueue.JobQueueCluster, optional
 
     :param jobs: Number of jobs to run in parallel, defaults to 4
     :type jobs: int
@@ -228,7 +228,8 @@ def _single_feature_to_inf(
     vars_to_drop: Sequence[str],
     posterior_predictive: str = None,
     log_likelihood: str = None,
-):
+) -> az.InferenceData:
+    """Convert single feature fit to InferenceData."""
     feat_inf = az.from_cmdstanpy(
         posterior=fit,
         posterior_predictive=posterior_predictive,

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -3,6 +3,8 @@ from typing import Sequence
 
 import arviz as az
 from cmdstanpy import CmdStanMCMC
+import dask
+import dask_jobqueue
 import numpy as np
 import xarray as xr
 
@@ -43,6 +45,9 @@ def single_fit_to_inference(
     :param log_likelihood: Name of log likelihood values from Stan model
         to include in ``arviz`` InferenceData object
     :type log_likelihood: str, optional
+
+    :returns: ``arviz`` InferenceData object with selected values
+    :rtype: az.InferenceData
     """
     # remove alr params so initial dim fitting works
     new_dims = {k: v for k, v in dims.items() if k not in alr_params}
@@ -109,6 +114,8 @@ def multiple_fits_to_inference(
     concatenation_name: str,
     posterior_predictive: str = None,
     log_likelihood: str = None,
+    dask_cluster: dask_jobqueue.JobQueueCluster = None,
+    jobs: int = 4
 ) -> az.InferenceData:
     """Save fitted parameters to xarray DataSet for multiple fits.
 
@@ -136,9 +143,18 @@ def multiple_fits_to_inference(
         to include in ``arviz`` InferenceData object
     :type log_likelihood: str, optional
 
+    :param dask_cluster: Dask jobqueue to run parallel jobs (optional)
+    :type dask_cluster: dask_jobqueue
+
+    :param jobs: Number of jobs to run in parallel, defaults to 4
+    :type jobs: int
+
     :returns: ``arviz`` InferenceData object with selected values
     :rtype: az.InferenceData
     """
+    if dask_cluster is not None:
+        dask_cluster.scale(jobs=jobs)
+
     # Remove the concatenation dimension from each individual fit
     new_dims = {
         k: [dim for dim in v if dim != concatenation_name]
@@ -149,37 +165,46 @@ def multiple_fits_to_inference(
     if new_dims == dims:
         raise ValueError("concatenation_name must match dimensions in dims")
 
-    po_list = []  # posterior
-    ss_list = []  # sample stats
-    pp_list = []  # posterior predictive
-    ll_list = []  # log likelihood
+    # Remove the unnecessary posterior dimensions
+    all_vars = fits[0].stan_variables().keys()
+    vars_to_drop = set(all_vars).difference(params)
+    if log_likelihood is not None:
+        vars_to_drop.remove(log_likelihood)
+    if posterior_predictive is not None:
+        vars_to_drop.remove(posterior_predictive)
+
+    inf_list = []
     for fit in fits:
-        ds = az.from_cmdstanpy(
-            posterior=fit,
+        single_feat_inf = _single_feature_to_inf(
+            fit=fit,
+            coords=coords,
+            dims=new_dims,
             posterior_predictive=posterior_predictive,
             log_likelihood=log_likelihood,
-            coords=coords,
-            dims=new_dims
+            vars_to_drop=vars_to_drop
         )
-        vars_to_drop = set(ds.posterior.data_vars).difference(params)
-        ds.posterior = _drop_data(ds.posterior, vars_to_drop)
+        inf_list.append(single_feat_inf)
 
-        po_list.append(ds.posterior)
-        ss_list.append(ds.sample_stats)
-        if log_likelihood is not None:
-            ll_list.append(ds.log_likelihood)
-        if posterior_predictive is not None:
-            pp_list.append(ds.posterior_predictive)
+    group_list = []
+    group_list.append(dask.persist(*[x.posterior for x in inf_list]))
+    group_list.append(dask.persist(*[x.sample_stats for x in inf_list]))
+    if log_likelihood is not None:
+        group_list.append(dask.persist(*[x.log_likelihood for x in inf_list]))
+    if posterior_predictive is not None:
+        group_list.append(
+            dask.persist(*[x.posterior_predictive for x in inf_list])
+        )
 
-    po_ds = xr.concat(po_list, concatenation_name)
-    ss_ds = xr.concat(ss_list, concatenation_name)
+    group_list = dask.compute(*group_list)
+    po_ds = xr.concat(group_list[0], concatenation_name)
+    ss_ds = xr.concat(group_list[1], concatenation_name)
     group_dict = {"posterior": po_ds, "sample_stats": ss_ds}
 
     if log_likelihood is not None:
-        ll_ds = xr.concat(ll_list, concatenation_name)
+        ll_ds = xr.concat(group_list[2], concatenation_name)
         group_dict["log_likelihood"] = ll_ds
     if posterior_predictive is not None:
-        pp_ds = xr.concat(pp_list, concatenation_name)
+        pp_ds = xr.concat(group_list[3], concatenation_name)
         group_dict["posterior_predictive"] = pp_ds
 
     all_group_inferences = []
@@ -195,9 +220,29 @@ def multiple_fits_to_inference(
     return az.concat(*all_group_inferences)
 
 
+@dask.delayed
+def _single_feature_to_inf(
+    fit: CmdStanMCMC,
+    coords: dict,
+    dims: dict,
+    vars_to_drop: Sequence[str],
+    posterior_predictive: str = None,
+    log_likelihood: str = None,
+):
+    feat_inf = az.from_cmdstanpy(
+        posterior=fit,
+        posterior_predictive=posterior_predictive,
+        log_likelihood=log_likelihood,
+        coords=coords,
+        dims=dims
+    )
+    feat_inf.posterior = _drop_data(feat_inf.posterior, vars_to_drop)
+    return feat_inf
+
+
 def _drop_data(
     dataset: xr.Dataset,
-    vars_to_drop: Sequence
+    vars_to_drop: Sequence[str],
 ) -> xr.Dataset:
     """Drop data and associated dimensions from inference group."""
     new_dataset = dataset.drop_vars(vars_to_drop)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,6 +51,7 @@ In Python:
 
     default_model_example
     custom_model
+    parallelization
     diagnosing_model
     writing_stan_code
     working_with_arviz

--- a/docs/parallelization.rst
+++ b/docs/parallelization.rst
@@ -1,0 +1,49 @@
+Fitting multiple features in parallel
+=====================================
+
+The default behavior in BIRDMAn is to fit 4 Markov chains in parallel for model fitting. With the high-dimensional nature of 'omics data, this can end up taking a long time. We provide an alternate way to model fitting in which you parallelize across *features* rather than chains. This allows for much faster computation if you have access to multiple cores such as in a HPC environment.
+
+.. note::
+
+    At the moment feature paralellization is only supported in the NegativeBinomial model by default. If you are implementing a custom model that works with parallelization you can still fit in this manner. Any model that can be decomposed into fitting individual models for each feature should work.
+
+We use `dask <https://docs.dask.org/en/latest/>`_ and `dask-jobqueue <https://jobqueue.dask.org/en/latest/>`_ to perform parallelization as they integrate with HPC very nicely. Please see the documentation of these two packages for more details.
+
+In this example we will assume that we have access to a SLURM cluster on which we can run BIRDMAn.
+
+.. code-block:: python
+
+    import biom
+    from birdman import NegativeBinomial
+    from dask_jobqueue import SLURMCluster
+    import pandas as pd
+
+    table = biom.load_table("example.biom")
+    metadata = pd.read_csv("metadata.tsv", sep="\t", index_col=0)
+
+    cluster = SLURMCluster(
+        cores=2,
+        processes=2,
+        memory='10GB',
+        walltime='01:00:00',
+        local_directory='/scratch'
+    )
+
+    nb = NegativeBinomial(
+        table=table,
+        metadata=metadata,
+        formula="diet",
+        chains=4,
+        seed=42,
+        parallelize_across="features"  # note this argument!
+    )
+    nb.compile_model()
+    nb.fit_model(dask_cluster=cluster, jobs=8)  # run 8 microbes at a time
+
+This code will run 8 microbes in parallel which will be faster than running the 4 chains in parallel. You can scale this up further depending on your computational resources by increasing the ``jobs`` argument.
+
+When fitting in parallel, CmdStanPy fits a model for each feature in your table. Converting to an ``InferenceData`` object is then just a matter of combining all the individual fits. We can also parallelize this process to speed-up runtime.
+
+.. code-block:: python
+
+    nb.to_inference_object(dask_cluster=cluster, jobs=8)

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - xarray
   - patsy
   - dask
+  - dask-jobqueue
   - biom-format
   - arviz
   - docutils==0.16

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "numpy",
         "cmdstanpy",
         "dask[complete]",
+        "dask-jobqueue",
         "biom-format",
         "patsy",
         "xarray",


### PR DESCRIPTION
Closes #27 and #11

Adds option for both fitting and converting to `InferenceData` to use a `dask_jobqueue` cluster. This has been tested and seems to work on PBS and SLURM at least.

~Still need to add info to the documentation about using `dask` with BIRDMAn.~