### PR TITLE
Abstract Model API further

### DIFF
--- a/birdman/__init__.py
+++ b/birdman/__init__.py
@@ -1,4 +1,5 @@
-from .model_base import Model
+from .model_base import BaseModel, RegressionModel
 from .default_models import NegativeBinomial, NegativeBinomialLME, Multinomial
 
-__all__ = ["Model", "NegativeBinomial", "NegativeBinomialLME", "Multinomial"]
+__all__ = ["BaseModel", "RegressionModel", "NegativeBinomial",
+           "NegativeBinomialLME", "Multinomial"]

--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -7,7 +7,7 @@ import dask_jobqueue
 import numpy as np
 import pandas as pd
 
-from .model_base import Model
+from .model_base import RegressionModel
 
 TEMPLATES = resource_filename("birdman", "templates")
 DEFAULT_MODEL_DICT = {
@@ -16,11 +16,12 @@ DEFAULT_MODEL_DICT = {
         "features": os.path.join(TEMPLATES, "negative_binomial_single.stan"),
         "lme": os.path.join(TEMPLATES, "negative_binomial_lme.stan")
     },
-    "multinomial": os.path.join(TEMPLATES, "multinomial.stan")
+    "multinomial": os.path.join(TEMPLATES, "multinomial.stan"),
+    "pln": os.path.join(TEMPLATES, "poisson_lognormal.stan")
 }
 
 
-class NegativeBinomial(Model):
+class NegativeBinomial(RegressionModel):
     """Fit count data using negative binomial model.
 
     .. math::
@@ -155,7 +156,7 @@ class NegativeBinomial(Model):
         return inf
 
 
-class NegativeBinomialLME(Model):
+class NegativeBinomialLME(RegressionModel):
     """Fit count data using negative binomial model considering subject as
     a random effect.
 
@@ -292,7 +293,7 @@ class NegativeBinomialLME(Model):
         return inf
 
 
-class Multinomial(Model):
+class Multinomial(RegressionModel):
     """Fit count data using serial multinomial model.
 
     .. math::

--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -17,7 +17,6 @@ DEFAULT_MODEL_DICT = {
         "lme": os.path.join(TEMPLATES, "negative_binomial_lme.stan")
     },
     "multinomial": os.path.join(TEMPLATES, "multinomial.stan"),
-    "pln": os.path.join(TEMPLATES, "poisson_lognormal.stan")
 }
 
 

--- a/docs/custom_model.rst
+++ b/docs/custom_model.rst
@@ -206,13 +206,13 @@ We will save the below file to ``negative_binomial_re.stan`` so we can import an
 Running BIRDMAn
 ---------------
 
-We will now pass this file along with our table, metadata, and formula into BIRDMAn. Note that we are using the base ``Model`` class for our custom model.
+We will now pass this file along with our table, metadata, and formula into BIRDMAn. Note that we are using the base ``RegressionModel`` class for our custom model.
 
 .. code-block:: python
 
     import birdman
 
-    nb_lme = birdman.Model(  # note that we are instantiating a base Model object
+    nb_lme = birdman.RegressionModel(
         table=filt_tbl,
         formula="C(time_point, Treatment('pre-deworm'))",
         metadata=metadata_model.loc[samps_to_keep],

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,21 +1,30 @@
 BIRDMAn Model Object
 ====================
 
-Base Model
-----------
-
-This is the base class for fitting a BIRDMAn model. If you are using a custom model you should instantiate/inherit this class.
-
-.. automodule:: birdman.model_base
-    :members:
-
-
 Default Models
 --------------
+
+These are the default models that are included in BIRDMAn. They should be usable with minimal knowledge of Stan and are good general purpose models.
 
 .. autoclass:: birdman.default_models.NegativeBinomial
     :members:
 .. autoclass:: birdman.default_models.NegativeBinomialLME
     :members:
 .. autoclass:: birdman.default_models.Multinomial
+    :members:
+
+Regression Model
+----------------
+
+You should inherit/instantiate this class if you are building a custom regression model with a design matrix.
+
+.. autoclass:: birdman.model_base.RegressionModel
+    :members:
+
+Base Model
+----------
+
+This is the base model of BIRDMAn used for more complicated models. Primarily for advanced users.
+
+.. autoclass:: birdman.model_base.BaseModel
     :members:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # Inspired by the EMPress setup.py file
 from setuptools import find_packages, setup
 
-__version__ = "0.0.2"
+__version__ = "0.0.3dev"
 
 classifiers = """
     Development Status :: 3 - Alpha

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -2,13 +2,13 @@ from pkg_resources import resource_filename
 
 import numpy as np
 
-from birdman import Model
+from birdman import RegressionModel
 
 
 def test_custom_model(table_biom, metadata):
     # Negative binomial model with separate prior values for intercept &
     # host_common_name effect and constant overdispersion parameter.
-    custom_model = Model(
+    custom_model = RegressionModel(
         table=table_biom,
         formula="host_common_name",
         metadata=metadata,


### PR DESCRIPTION
cc @mortonjt

Relevant to #34, closes #37

Creates a new class `BaseModel` that doesn't require a formula for a design matrix. `Model` class renamed to `RegressionModel`.