### PR TITLE
Refactor conversion to InferenceData

### DIFF
--- a/birdman/default_models.py
+++ b/birdman/default_models.py
@@ -1,7 +1,6 @@
 import os
 from pkg_resources import resource_filename
 
-import arviz as az
 import biom
 import numpy as np
 import pandas as pd
@@ -107,21 +106,23 @@ class NegativeBinomial(RegressionModel):
         }
         self.add_parameters(param_dict)
 
-        self.specifications["params"] = ["beta", "phi"]
-        self.specifications["dims"] = {
-            "beta": ["covariate", "feature"],
-            "phi": ["feature"],
-            "log_lhood": ["tbl_sample", "feature"],
-            "y_predict": ["tbl_sample", "feature"]
-        }
-        self.specifications["coords"] = {
-            "covariate": self.colnames,
-            "feature": self.feature_names,
-            "tbl_sample": self.sample_names
-        }
-        self.specifications["include_observed_data"] = True
-        self.specifications["posterior_predictive"] = "y_predict"
-        self.specifications["log_likelihood"] = "log_lhood"
+        self.specify_model(
+            params=["beta", "phi"],
+            dims={
+                "beta": ["covariate", "feature"],
+                "phi": ["feature"],
+                "log_lhood": ["tbl_sample", "feature"],
+                "y_predict": ["tbl_sample", "feature"]
+            },
+            coords={
+                "covariate": self.colnames,
+                "feature": self.feature_names,
+                "tbl_sample": self.sample_names
+            },
+            include_observed_data=True,
+            posterior_predictive="y_predict",
+            log_likelihood="log_lhood"
+        )
 
         if self.parallelize_across == "chains":
             self.specifications["alr_params"] = ["beta"]
@@ -231,23 +232,25 @@ class NegativeBinomialLME(RegressionModel):
         }
         self.add_parameters(param_dict)
 
-        self.specifications["params"] = ["beta", "phi"]
-        self.specifications["dims"] = {
-            "beta": ["covariate", "feature"],
-            "phi": ["feature"],
-            "subj_int": ["group", "feature"],
-            "log_lhood": ["tbl_sample", "feature"],
-            "y_predict": ["tbl_sample", "feature"]
-        }
-        self.specifications["coords"] = {
-            "covariate": self.colnames,
-            "feature": self.feature_names,
-            "tbl_sample": self.sample_names,
-            "group": self.groups
-        }
-        self.specifications["include_observed_data"] = True
-        self.specifications["posterior_predictive"] = "y_predict"
-        self.specifications["log_likelihood"] = "log_lhood"
+        self.specify_model(
+            params=["beta", "phi", "subj_int"],
+            dims={
+                "beta": ["covariate", "feature"],
+                "phi": ["feature"],
+                "subj_int": ["group", "feature"],
+                "log_lhood": ["tbl_sample", "feature"],
+                "y_predict": ["tbl_sample", "feature"]
+            },
+            coords={
+                "covariate": self.colnames,
+                "feature": self.feature_names,
+                "tbl_sample": self.sample_names,
+                "group": self.groups
+            },
+            include_observed_data=True,
+            posterior_predictive="y_predict",
+            log_likelihood="log_lhood"
+        )
 
         if self.parallelize_across == "chains":
             self.specifications["alr_params"] = ["beta", "subj_int"]
@@ -324,31 +327,19 @@ class Multinomial(RegressionModel):
         }
         self.add_parameters(param_dict)
 
-    def to_inference_object(self) -> az.InferenceData:
-        """Convert fitted Stan model into ``arviz`` InferenceData object.
-
-        :returns: ``arviz`` InferenceData object with selected values
-        :rtype: az.InferenceData
-        """
-        dims = {
-            "beta": ["covariate", "feature"],
-            "log_lhood": ["tbl_sample"],
-            "y_predict": ["tbl_sample", "feature"]
-        }
-        coords = {
-            "covariate": self.colnames,
-            "feature": self.feature_names,
-            "tbl_sample": self.sample_names
-        }
-
-        # TODO: May want to allow not passing PP/LL/OD in the future
-        inf = super().to_inference_object(
-            params=["beta", "phi"],
-            dims=dims,
-            coords=coords,
-            alr_params=["beta"],
-            posterior_predictive="y_predict",
-            log_likelihood="log_lhood",
+        self.specify_model(
+            params=["beta"],
+            dims={
+                "beta": ["covariate", "feature"],
+                "log_lhood": ["tbl_sample"],
+                "y_predict": ["tbl_sample", "feature"]
+            },
+            coords={
+                "covariate": self.colnames,
+                "feature": self.feature_names,
+                "tbl_sample": self.sample_names,
+            },
             include_observed_data=True,
+            posterior_predictive="y_predict",
+            log_likelihood="log_lhood"
         )
-        return inf

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -10,7 +10,7 @@ import pandas as pd
 from patsy import dmatrix
 
 from .model_util import (single_fit_to_inference, multiple_fits_to_inference,
-                         _single_feature_to_inf)
+                         _single_feature_to_inf, concatenate_inferences)
 
 
 class BaseModel:
@@ -299,9 +299,18 @@ class BaseModel:
         # if already Inference, just return
         if isinstance(self.fit, az.InferenceData):
             return self.fit
-        if isinstance(self.fit, list):
+        # if sequence of Inferences, concatenate if specified
+        if isinstance(self.fit, list) or isinstance(self.fit, tuple):
             if isinstance(self.fit[0], az.InferenceData):
-                return self.fit
+                if combine_individual_fits:
+                    cat_name = self.specifications["concatenation_name"]
+                    return concatenate_inferences(
+                        self.fit,
+                        coords=self.specifications["coords"],
+                        concatenation_name=cat_name
+                    )
+                else:
+                    return self.fit
 
         args = {
             k: self.specifications.get(k)

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -289,11 +289,22 @@ class BaseModel:
         if not auto_convert:
             return _fit
         else:
+            all_vars = _fit.stan_variables().keys()
+            vars_to_drop = set(all_vars).difference(self.specifications.get(
+                "params"
+            ))
+            ll = self.specifications.get("log_likelihood")
+            pp = self.specifications.get("posterior_predictive")
+            if ll is not None:
+                vars_to_drop.remove(ll)
+            if pp is not None:
+                vars_to_drop.remove(pp)
+
             _inf = _single_feature_to_inf(
                 fit=_fit,
                 coords=self.specifications["coords"],
                 dims=new_dims,
-                vars_to_drop=[],
+                vars_to_drop=vars_to_drop,
                 posterior_predictive=self.specifications.get(
                     "posterior_predictive"
                 ),

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -148,7 +148,14 @@ class BaseModel:
         :param sampler_args: Additional parameters to pass to CmdStanPy
             sampler (optional)
         :type sampler_args: dict
+
+        :param convert_to_inference: Whether to automatically convert the
+            fitted model to an az.InferenceData object (defaults to False)
+        :type convert_to_inference: bool
         """
+        if self.sm is None:
+            raise ValueError("Model must be compiled first!")
+
         if self.parallelize_across == "features":
             cn = self.specifications["concatenation_name"]
             self.specifications["dims"] = {

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -4,7 +4,6 @@ from typing import List, Sequence, Union
 import arviz as az
 from cmdstanpy import CmdStanMCMC
 import dask
-import dask_jobqueue
 import numpy as np
 import xarray as xr
 
@@ -115,8 +114,6 @@ def multiple_fits_to_inference(
     concatenation_name: str = "feature",
     posterior_predictive: str = None,
     log_likelihood: str = None,
-    dask_cluster: dask_jobqueue.JobQueueCluster = None,
-    jobs: int = 4
 ) -> Union[az.InferenceData, List[az.InferenceData]]:
     """Save fitted parameters to xarray DataSet for multiple fits.
 

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -175,7 +175,7 @@ def multiple_fits_to_inference(
 
     inf_list = []
     for fit in fits:
-        single_feat_inf = _single_feature_to_inf(
+        single_feat_inf = dask.delayed(_single_feature_to_inf)(
             fit=fit,
             coords=coords,
             dims=new_dims,
@@ -220,7 +220,6 @@ def multiple_fits_to_inference(
     return az.concat(*all_group_inferences)
 
 
-@dask.delayed
 def _single_feature_to_inf(
     fit: CmdStanMCMC,
     coords: dict,

--- a/docs/custom_model.rst
+++ b/docs/custom_model.rst
@@ -14,8 +14,8 @@ First we will download the BIOM table and metadata from Qiita.
 
 .. code-block:: bash
 
-    wget -O data.zip "https://qiita.ucsd.edu/public_artifact_download/?artifact_id=44773"
-    wget -O metadata.zip "https://qiita.ucsd.edu/public_download/?data=sample_information&study_id=107"
+    wget -O data.zip "https://qiita.ucsd.edu/public_artifact_download/?artifact_id=94270"
+    wget -O metadata.zip "https://qiita.ucsd.edu/public_download/?data=sample_information&study_id=11913"
     unzip data.zip
     unzip metadata.zip
 
@@ -265,20 +265,6 @@ Now we can add all the necessary parameters to BIRDMAn with the ``add_parameters
     }
     nb_lme.add_parameters(param_dict)
 
-Finally, we compile and fit the model.
-
-.. note::
-
-    Fitting this model took approximately 6 minutes on my laptop.
-
-.. code-block:: python
-
-    nb_lme.compile_model()
-    nb_lme.fit_model()
-
-Converting to ``InferenceData``
--------------------------------
-
 With a custom model there is a bit more legwork involved in converting to the ``arviz.InferenceData`` data structure. We will step through each of the parameters in this example.
 
 * ``params``: List of parameters you want to include in the posterior draws (must match Stan code).
@@ -289,9 +275,11 @@ With a custom model there is a bit more legwork involved in converting to the ``
 * ``log_likelihood``: Name of variable holding log likelihood values (optional).
 * ``include_observed_data``: Whether to include the original feature table as a group. This is useful for certain diagnostics.
 
+We pass all these arguments into the ``specify_model`` method of the ``Model`` object.
+
 .. code-block:: python
 
-    inference = nb_lme.to_inference_object(
+    nb_lme.specify_model(
         params=["beta", "phi", "subj_int"],
         dims={
             "beta": ["covariate", "feature"],
@@ -311,5 +299,25 @@ With a custom model there is a bit more legwork involved in converting to the ``
         log_likelihood="log_lik",
         include_observed_data=True
     )
+
+Finally, we compile and fit the model.
+
+.. note::
+
+    Fitting this model took approximately 6 minutes on my laptop.
+
+.. code-block:: python
+
+    nb_lme.compile_model()
+    nb_lme.fit_model()
+
+Converting to ``InferenceData``
+-------------------------------
+
+When the model has finished fitting, you can convert to an inference data assuming you have specified your model previously.
+
+.. code-block:: python
+
+    inference = nb_lme.to_inference_object()
 
 With this you can use the rest of the BIRDMAn suite as usual or directly interact with the ``arviz`` library!

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - xarray
   - patsy
   - dask
-  - dask-jobqueue
   - biom-format
   - arviz
   - docutils==0.16

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # Inspired by the EMPress setup.py file
 from setuptools import find_packages, setup
 
-__version__ = "0.0.3dev"
+__version__ = "0.0.3"
 
 classifiers = """
     Development Status :: 3 - Alpha
@@ -39,7 +39,6 @@ setup(
         "numpy",
         "cmdstanpy",
         "dask[complete]",
-        "dask-jobqueue",
         "biom-format",
         "patsy",
         "xarray",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ from birdman import NegativeBinomial
 TEST_DATA = resource_filename("tests", "data")
 TBL_FILE = os.path.join(TEST_DATA, "macaque_tbl.biom")
 MD_FILE = os.path.join(TEST_DATA, "macaque_metadata.tsv")
-print(TBL_FILE)
 
 
 def example_biom():
@@ -91,5 +90,5 @@ def example_inf():
 @pytest.fixture(scope="session")
 def example_parallel_inf():
     nb = parallel_model()
-    inference = nb.to_inference_object()
+    inference = nb.to_inference_object(combine_individual_fits=True)
     return inference

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -26,10 +26,7 @@ def test_custom_model(table_biom, metadata):
             "depth": np.log(custom_model.table.sum(axis="sample")),
         }
     )
-    custom_model.compile_model()
-    custom_model.fit_model()
-
-    inference = custom_model.to_inference_object(
+    custom_model.specify_model(
         params=["beta_var"],
         coords={
             "feature": custom_model.feature_names,
@@ -41,6 +38,9 @@ def test_custom_model(table_biom, metadata):
         },
         alr_params=["beta_var"]
     )
+    custom_model.compile_model()
+    custom_model.fit_model()
+    inference = custom_model.to_inference_object()
 
     assert set(inference.groups()) == {"posterior", "sample_stats"}
     ds = inference.posterior

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -17,6 +17,5 @@ def test_r2_score(example_inf, example_parallel_inf):
 
 
 def test_loo(example_inf, example_parallel_inf):
-    print(example_inf)
     diag.loo(example_inf)
     diag.loo(example_parallel_inf)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,6 +1,7 @@
 import os
 from pkg_resources import resource_filename
 
+from arviz import InferenceData
 import numpy as np
 
 from birdman import Multinomial, NegativeBinomial, NegativeBinomialLME
@@ -98,14 +99,13 @@ class TestToInference:
             formula="host_common_name",
             metadata=metadata,
             chains=4,
+            num_iter=100,
             seed=42,
             beta_prior=2.0,
             cauchy_scale=2.0,
             parallelize_across="features"
         )
         nb.compile_model()
-        nb.fit_model(
-            auto_convert_to_inference=True
-        )
-        assert len(nb.inf) == 28
+        nb.fit_model(convert_to_inference=True)
         assert len(nb.fit) == 28
+        assert isinstance(nb.fit[0], InferenceData)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -85,3 +85,27 @@ class TestToInference:
         target_groups = {"posterior", "sample_stats", "log_likelihood",
                          "posterior_predictive", "observed_data"}
         assert set(inference_data.groups()) == target_groups
+
+    def test_parallel_to_inference_no_concat(self, example_parallel_model):
+        inf = example_parallel_model.to_inference_object(
+            combine_individual_fits=False
+        )
+        assert len(inf) == 28
+
+    def test_parallel_auto_inf(self, table_biom, metadata):
+        nb = NegativeBinomial(
+            table=table_biom,
+            formula="host_common_name",
+            metadata=metadata,
+            chains=4,
+            seed=42,
+            beta_prior=2.0,
+            cauchy_scale=2.0,
+            parallelize_across="features"
+        )
+        nb.compile_model()
+        nb.fit_model(
+            auto_convert_to_inference=True
+        )
+        assert len(nb.inf) == 28
+        assert len(nb.fit) == 28

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -61,6 +61,27 @@ class TestToInference:
         )
         self.dataset_comparison(example_parallel_model, inf.posterior)
 
+    def test_parallel_to_inference_no_concat(self, example_parallel_model):
+        inf = mu.multiple_fits_to_inference(
+            fits=example_parallel_model.fit,
+            params=["beta", "phi"],
+            coords={
+                "feature": example_parallel_model.feature_names,
+                "covariate": example_parallel_model.colnames
+            },
+            dims={
+                "beta": ["covariate", "feature"],
+                "phi": ["feature"]
+            },
+            concatenate=False,
+            log_likelihood="log_lhood",
+            posterior_predictive="y_predict",
+        )
+        assert len(inf) == 28
+        exp_groups = {"sample_stats", "posterior", "log_likelihood",
+                      "posterior_predictive"}
+        assert set(inf[0].groups()) == exp_groups
+
     def test_parallel_to_inference_wrong_concat(self, example_parallel_model):
         with pytest.raises(ValueError) as excinfo:
             mu.multiple_fits_to_inference(

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -97,8 +97,8 @@ class TestToInference:
                 },
                 concatenation_name="mewtwo",
             )
-        assert str(excinfo.value) == ("concatenation_name must match "
-                                      "dimensions in dims")
+        assert str(excinfo.value) == ("different number of dimensions on "
+                                      "data and dims: 3 vs 4")
 
 
 # Posterior predictive & log likelihood


### PR DESCRIPTION
cc @mortonjt

Refactor of InferenceData conversion code. Adds a flag to automatically convert a fitted `CmdStanMCMC` to `InferenceData`. For parallelized models this should convert after each fit and *not* after all are completed. If this flag is specified, the `BaseModel.fit` object will be of type `InferenceData` or `List[InferenceData]`.

Also changes the way `to_inference_object` works. Now, an arbitrary `BaseModel` class should call the `specify_model` method to pass in params, coords, dims, etc. `to_inference_object` now uses these specifications instead of taking them as arguments.

Still need to update documentation. After this will probably bump up version to 0.0.3.