### PR TITLE
ENH : Adding support for chunking

### DIFF
--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -143,6 +143,7 @@ class BaseModel:
         self,
         sampler_args: dict = None,
         convert_to_inference: bool = False,
+        chunksize=10
     ) -> None:
         """Fit model according to parallelization configuration.
 
@@ -166,7 +167,8 @@ class BaseModel:
             }
             self._fit_parallel(
                 sampler_args=sampler_args,
-                convert_to_inference=convert_to_inference
+                convert_to_inference=convert_to_inference,
+                chunk_size=chunk_size
             )
         elif self.parallelize_across == "chains":
             self._fit_serial(
@@ -234,7 +236,8 @@ class BaseModel:
             sampler_args = dict()
 
         _fits = []
-        d_ids = da.from_array(self.table.ids(axis='observation'), chunks=(chunk_size))
+        d_ids = da.from_array(self.table.ids(axis='observation'),
+                              chunks=(chunk_size))
         for i in range(len(d_ids)):
             v = self.table.data(id=d_ids[i])
             _fit = dask.delayed(self._fit_single)(

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -143,7 +143,7 @@ class BaseModel:
         self,
         sampler_args: dict = None,
         convert_to_inference: bool = False,
-        chunksize=10
+        chunks=100
     ) -> None:
         """Fit model according to parallelization configuration.
 
@@ -168,7 +168,7 @@ class BaseModel:
             self._fit_parallel(
                 sampler_args=sampler_args,
                 convert_to_inference=convert_to_inference,
-                chunk_size=chunk_size
+                chunks=chunks
             )
         elif self.parallelize_across == "chains":
             self._fit_serial(
@@ -219,7 +219,7 @@ class BaseModel:
         self,
         convert_to_inference: bool = False,
         sampler_args: dict = None,
-        chunk_size=10
+        chunks=10
     ) -> Union[List[CmdStanMCMC], List[az.InferenceData]]:
         """Fit model by parallelizing across features.
 
@@ -237,7 +237,7 @@ class BaseModel:
 
         _fits = []
         d_ids = da.from_array(self.table.ids(axis='observation'),
-                              chunks=(chunk_size))
+                              chunks=(chunks))
         for i in range(len(d_ids)):
             v = self.table.data(id=d_ids[i])
             _fit = dask.delayed(self._fit_single)(

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -5,7 +5,6 @@ import arviz as az
 import biom
 from cmdstanpy import CmdStanModel, CmdStanMCMC
 import dask
-import dask.array as da
 import numpy as np
 import pandas as pd
 from patsy import dmatrix

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -251,8 +251,8 @@ class BaseModel:
         batches = []
 
         for i in range(0, len(self.table.ids(axis='observation')), chunksize):
-
-            result_batch = dask.delayed(batch_f)(range(i, i + chunksize))
+            end = min(len(self.table.ids(axis='observation')), i + chunksize)
+            result_batch = dask.delayed(batch_f)(range(i, end))
             batches.append(result_batch)
 
         fit_futures = dask.persist(*batches)


### PR DESCRIPTION
ok, so I did a bit more careful profiling of Birdman.  

It turns out that it is very easy to overwhelm the dask scheduler -- dask does not like dealing with many disjoint tasks.
If there are thousands of tasks, the scheduler will grind to a screeching halt.
So while I was able to run Birdman on a couple of my jobs, there are a few instances where Birdman will not work.

The trick is to add support for [chunking](https://docs.dask.org/en/latest/delayed-best-practices.html#avoid-too-many-tasks); so rather than giving a worker a single feature to work on, give them several features.  Larger chunk sizes will reduce the size of the computation graph, and make these operations more feasible.

I've tested this on some of my larger datasets, so I believe that this will do the trick.