### PR TITLE
Refactor model API for abstract parallelization

### DIFF
--- a/birdman/__init__.py
+++ b/birdman/__init__.py
@@ -1,5 +1,7 @@
-from .model_base import BaseModel, RegressionModel
-from .default_models import NegativeBinomial, NegativeBinomialLME, Multinomial
+from .model_base import BaseModel, TableModel, SingleFeatureModel
+from .default_models import (NegativeBinomial, NegativeBinomialLME,
+                             NegativeBinomialSingle, Multinomial)
 
-__all__ = ["BaseModel", "RegressionModel", "NegativeBinomial",
+__all__ = ["BaseModel", "TableModel", "SingleFeatureModel",
+           "NegativeBinomial", "NegativeBinomialSingle",
            "NegativeBinomialLME", "Multinomial"]

--- a/birdman/__init__.py
+++ b/birdman/__init__.py
@@ -1,7 +1,8 @@
-from .model_base import BaseModel, TableModel, SingleFeatureModel
+from .model_base import (BaseModel, TableModel, SingleFeatureModel,
+                         ModelIterator)
 from .default_models import (NegativeBinomial, NegativeBinomialLME,
                              NegativeBinomialSingle, Multinomial)
 
-__all__ = ["BaseModel", "TableModel", "SingleFeatureModel",
+__all__ = ["BaseModel", "TableModel", "SingleFeatureModel", "ModelIterator",
            "NegativeBinomial", "NegativeBinomialSingle",
            "NegativeBinomialLME", "Multinomial"]

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -261,7 +261,7 @@ class SingleFeatureModel(BaseModel):
         if isinstance(self.fit, az.InferenceData):
             return self.fit
 
-        if "alr_params" in self.specifications:
+        if self.specifications.get("alr_params") is not None:
             warnings.warn("alr_params ignored when fitting a single feature")
 
         args = {

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -175,11 +175,12 @@ class BaseModel(ABC):
             try:
                 self.fit = self.to_inference_object()
             except Exception as e:
-                print(
-                    "Auto conversion to InferenceData has failed! "
-                    "self.fit has been saved as CmdStanMCMC instead."
+                warnings.warn(
+                    "Auto conversion to InferenceData has failed! fit has "
+                    "been saved as CmdStanMCMC instead. See error message"
+                    f": \n{type(e).__name__}: {e}",
+                    category=UserWarning
                 )
-                print(str(e))
 
     @abstractmethod
     def to_inference_object(self):
@@ -205,6 +206,9 @@ class TableModel(BaseModel):
         # if already Inference, just return
         if isinstance(self.fit, az.InferenceData):
             return self.fit
+
+        if not self.specifications:
+            raise ValueError("Specification dictionary is empty!")
 
         args = {
             k: self.specifications.get(k)

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -310,8 +310,7 @@ class ModelIterator:
         self.feature_names = table.ids(axis="observation")
         self.model_type = model
         self.models = [
-            model(table, fid, **kwargs)
-            for fid in table.ids(axis="observation")
+            model(table, fid, **kwargs) for fid in self.feature_names
         ]
 
     def __iter__(self):

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -85,7 +85,7 @@ class BaseModel(ABC):
         }
         self.add_parameters(param_dict)
 
-    def compile_model(self) -> None:
+    def compile_model(self):
         """Compile Stan model."""
         self.sm = CmdStanModel(stan_file=self.model_path)
 
@@ -98,7 +98,7 @@ class BaseModel(ABC):
         include_observed_data: bool = False,
         posterior_predictive: str = None,
         log_likelihood: str = None,
-    ) -> None:
+    ):
         """Specify coordinates and dimensions of model.
 
         :param params: Posterior fitted parameters to include
@@ -134,7 +134,7 @@ class BaseModel(ABC):
         self.specifications["posterior_predictive"] = posterior_predictive
         self.specifications["log_likelihood"] = log_likelihood
 
-    def add_parameters(self, param_dict: dict = None) -> None:
+    def add_parameters(self, param_dict: dict = None):
         """Add parameters from dict to be passed to Stan."""
         if param_dict is None:
             param_dict = dict()

--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -168,17 +168,18 @@ class BaseModel(ABC):
             **sampler_args
         )
 
+        self.fit = _fit
+
         # If auto-conversion fails, fit will be of type CmdStanMCMC
         if convert_to_inference:
             try:
-                _fit = self.to_inference_object()
+                self.fit = self.to_inference_object()
             except Exception as e:
                 print(
                     "Auto conversion to InferenceData has failed! "
                     "self.fit has been saved as CmdStanMCMC instead."
                 )
                 print(str(e))
-        self.fit = _fit
 
     @abstractmethod
     def to_inference_object(self):

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -135,7 +135,8 @@ def single_feature_fit_to_inference(
     :rtype: az.InferenceData
     """
     _coords = coords.copy()
-    _coords.pop("feature")
+    if "feature" in coords:
+        _coords.pop("feature")
 
     _dims = dims.copy()
     for k, v in _dims.items():

--- a/birdman/model_util.py
+++ b/birdman/model_util.py
@@ -9,7 +9,7 @@ import xarray as xr
 from .util import convert_beta_coordinates
 
 
-def single_fit_to_inference(
+def full_fit_to_inference(
     fit: CmdStanMCMC,
     params: Sequence[str],
     coords: dict,
@@ -103,7 +103,7 @@ def single_fit_to_inference(
     return inference
 
 
-def single_feature_to_inf(
+def single_feature_fit_to_inference(
     fit: CmdStanMCMC,
     params: Sequence[str],
     coords: dict,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import biom
 import pandas as pd
 import pytest
 
-from birdman import NegativeBinomial
+from birdman import NegativeBinomial, NegativeBinomialSingle
 
 TEST_DATA = resource_filename("tests", "data")
 TBL_FILE = os.path.join(TEST_DATA, "macaque_tbl.biom")
@@ -69,18 +69,18 @@ def single_feat_model():
     tbl = example_biom()
     md = example_metadata()
 
-    nb = NegativeBinomial(
+    id0 = tbl.ids(axis="observation")[0]
+    nb = NegativeBinomialSingle(
         table=tbl,
         formula="host_common_name",
         metadata=md,
-        single_feature=True,
+        feature_id=id0,
         num_iter=100,
         chains=4,
     )
 
     nb.compile_model()
-    id0 = tbl.ids(axis="observation")[0]
-    nb.fit_model(feature_id=id0)
+    nb.fit_model()
 
     return nb
 

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -24,7 +24,7 @@ def test_custom_model(table_biom, metadata):
             "B_p_1": 2.0,
             "B_p_2": 5.0,
             "phi_s": 0.2,
-            "depth": np.log(custom_model.table.sum(axis="sample")),
+            "depth": np.log(table_biom.sum(axis="sample")),
         }
     )
     custom_model.specify_model(

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -2,20 +2,22 @@ from pkg_resources import resource_filename
 
 import numpy as np
 
-from birdman import RegressionModel
+from birdman import TableModel
 
 
 def test_custom_model(table_biom, metadata):
     # Negative binomial model with separate prior values for intercept &
     # host_common_name effect and constant overdispersion parameter.
-    custom_model = RegressionModel(
+    custom_model = TableModel(
         table=table_biom,
-        formula="host_common_name",
-        metadata=metadata,
         model_path=resource_filename("tests", "custom_model.stan"),
         num_iter=100,
         chains=4,
         seed=42,
+    )
+    custom_model.create_regression(
+        formula="host_common_name",
+        metadata=metadata,
     )
     custom_model.add_parameters(
         {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,7 +3,8 @@ from pkg_resources import resource_filename
 
 import numpy as np
 
-from birdman import Multinomial, NegativeBinomial, NegativeBinomialLME
+from birdman import (Multinomial, NegativeBinomial, NegativeBinomialLME,
+                     NegativeBinomialSingle)
 
 TEMPLATES = resource_filename("birdman", "templates")
 
@@ -73,17 +74,16 @@ class TestModelFit:
 
     def test_single_feat(self, table_biom, metadata):
         md = metadata.copy()
-        nb = NegativeBinomial(
-            table=table_biom,
-            formula="host_common_name",
-            single_feature=True,
-            metadata=md,
-            num_iter=100,
-        )
-        nb.compile_model()
-
         for fid in table_biom.ids(axis="observation"):
-            nb.fit_model(feature_id=fid)
+            nb = NegativeBinomialSingle(
+                table=table_biom,
+                feature_id=fid,
+                formula="host_common_name",
+                metadata=md,
+                num_iter=100,
+            )
+            nb.compile_model()
+            nb.fit_model()
 
 
 class TestToInference:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -94,11 +94,11 @@ class TestModelFit:
             num_iter=100,
         )
         nb.compile_model()
-        nb.specifications = dict()
+        nb.specified = False
         with pytest.warns(UserWarning) as r:
             nb.fit_model(convert_to_inference=True)
 
-        e = "Specification dictionary is empty!"
+        e = "Model has not been specified!"
         expected_warning = (
             "Auto conversion to InferenceData has failed! fit has "
             "been saved as CmdStanMCMC instead. See error message"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -83,7 +83,7 @@ class TestModelFit:
                 num_iter=100,
             )
             nb.compile_model()
-            nb.fit_model()
+            nb.fit_model(convert_to_inference=True)
 
 
 class TestToInference:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,6 +2,7 @@ import os
 from pkg_resources import resource_filename
 
 import numpy as np
+import pytest
 
 from birdman import (Multinomial, NegativeBinomial, NegativeBinomialLME,
                      NegativeBinomialSingle)
@@ -84,6 +85,26 @@ class TestModelFit:
             )
             nb.compile_model()
             nb.fit_model(convert_to_inference=True)
+
+    def test_fail_auto_conversion(self, table_biom, metadata):
+        nb = NegativeBinomial(
+            table=table_biom,
+            metadata=metadata,
+            formula="host_common_name",
+            num_iter=100,
+        )
+        nb.compile_model()
+        nb.specifications = dict()
+        with pytest.warns(UserWarning) as r:
+            nb.fit_model(convert_to_inference=True)
+
+        e = "Specification dictionary is empty!"
+        expected_warning = (
+            "Auto conversion to InferenceData has failed! fit has "
+            "been saved as CmdStanMCMC instead. See error message"
+            f": \nValueError: {e}"
+        )
+        assert r[0].message.args[0] == expected_warning
 
 
 class TestToInference:

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -10,7 +10,7 @@ class TestToInference:
         assert set(ds["beta"].shape) == {2, 28, 4, 100}
         assert set(ds["phi"].shape) == {28, 4, 100}
 
-        exp_feature_names = model.table.ids(axis="observation")
+        exp_feature_names = model.feature_names
         ds_feature_names = ds.coords["feature"]
         assert (exp_feature_names == ds_feature_names).all()
 

--- a/tests/test_model_util.py
+++ b/tests/test_model_util.py
@@ -25,7 +25,7 @@ class TestToInference:
         assert (ds.coords["chain"] == [0, 1, 2, 3]).all()
 
     def test_serial_to_inference(self, example_model):
-        inf = mu.single_fit_to_inference(
+        inf = mu.full_fit_to_inference(
             fit=example_model.fit,
             coords={
                 "feature": example_model.feature_names,
@@ -47,7 +47,7 @@ class TestToInference:
 # Posterior predictive & log likelihood
 class TestPPLL:
     def test_serial_ppll(self, example_model):
-        inf = mu.single_fit_to_inference(
+        inf = mu.full_fit_to_inference(
             fit=example_model.fit,
             coords={
                 "feature": example_model.feature_names,


### PR DESCRIPTION
Closes #51 

Important changes:

- Removed `RegressionModel` subclass
- `BaseModel` is now an abstract class (cannot be directly instantiated)
- `BaseModel` has a `create_regression` method that behaves equivalently to the previous `RegressionModel`
- Added two subclasses - `TableModel` and `SingleFeatureModel` for serial & parallel models respectively
- Added a `ModelIterator` class
- Changed behavior of `specify_model` to save `params, coords, etc.` as attributes.
    - Other parameters such as `alr_params` can be passed and will be saved in the `self.specifications` dict
    - This was done so we are not limited to ALR models in `TableModel`. Will likely need to update/decompose `full_fit_to_inference` in the future.