### PR TITLE
Update installation instructions for new ArviZ release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,11 +36,7 @@ jobs:
 
       - name: Install conda packages
         shell: bash -l {0}
-        run: conda install -c conda-forge biom-format patsy pytest xarray scikit-bio flake8 cmdstanpy
-
-      - name: Install master branch of arviz
-        shell: bash -l {0}
-        run: pip install git+git://github.com/arviz-devs/arviz.git
+        run: conda install -c conda-forge biom-format patsy pytest xarray scikit-bio flake8 cmdstanpy arviz
 
       - name: Install BIRDMAn
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ See the [documentation](https://birdman.readthedocs.io/en/stable/?badge=stable) 
 Currently BIRDMAn requires Python 3.7 or higher.
 
 ```bash
-conda install -c conda-forge biom-format patsy xarray cmdstanpy
-pip install git+git://github.com/arviz-devs/arviz.git
+conda install -c conda-forge biom-format patsy xarray cmdstanpy arviz
 pip install birdman
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         "patsy",
         "xarray",
         "pandas",
-        "arviz"
+        "arviz>=0.11.2"
     ],
     extras_require={"dev": ["pytest", "scikit-bio", "sphinx"]},
     classifiers=[s.strip() for s in classifiers.split('\n') if s]


### PR DESCRIPTION
[Arviz v0.11.2](https://github.com/arviz-devs/arviz/releases/tag/v0.11.3) contains a change that is crucial to handling multi-dimensional posterior draws. This change should hopefully allow us to install ArviZ via conda/pip rather than installing from the GitHub master branch as before.

See https://github.com/mortonjt/q2-differential/issues/1 & https://github.com/gibsramen/BIRDMAn/issues/15