### PR TITLE
Add chunking support to ModelIterator

### DIFF
--- a/birdman/model_base.py
+++ b/birdman/model_base.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from math import ceil
 from typing import Sequence
 import warnings
 
@@ -299,14 +300,31 @@ class ModelIterator:
         self,
         table: biom.Table,
         model: SingleFeatureModel,
+        num_chunks: int = None,
         **kwargs
     ):
         self.feature_names = table.ids(axis="observation")
+        self.size = table.shape[0]
         self.model_type = model
-        self.models = [
-            model(table, fid, **kwargs) for fid in self.feature_names
-        ]
+        self.num_chunks = num_chunks
+        models = [model(table, fid, **kwargs) for fid in self.feature_names]
+
+        if num_chunks is None:
+            self.chunks = list(zip(self.feature_names, models))
+        else:
+            chunk_size = ceil(self.size / num_chunks)
+            self.chunks = []
+            for i in range(0, self.size, step=chunk_size):
+                self.chunks.append(
+                    (
+                        self.feature_names[i: i+chunk_size],
+                        models[i: i+chunk_size])
+                    )
+                )
 
     def __iter__(self):
-        for fid, model in zip(self.feature_names, self.models):
-            yield fid, model
+        for fids, models in chunks:
+            yield fids, models
+
+    def __getitem__(self, chunk_idx: int):
+        return self.chunks[chunk_dix]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,17 +16,17 @@ import sys
 sys.path.insert(0, os.path.abspath('..'))
 
 # https://blog.rtwilson.com/how-to-make-your-sphinx-documentation-compile-with-readthedocs-when-youre-using-numpy-and-scipy/
-MOCK_MODULES = [
-    "numpy",
-    "scipy",
-    "scipy.stats",
-    "matplotlib",
-    "matplotlib.pyplot",
-    "cmdstanpy",
-    "arviz"
-]
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = mock.Mock()
+# MOCK_MODULES = [
+#     "numpy",
+#     "scipy",
+#     "scipy.stats",
+#     "matplotlib",
+#     "matplotlib.pyplot",
+#     "cmdstanpy",
+#     "arviz"
+# ]
+# for mod_name in MOCK_MODULES:
+#     sys.modules[mod_name] = mock.Mock()
 
 
 # -- Project information -----------------------------------------------------

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -158,6 +158,41 @@ class TestModelIterator:
         np.testing.assert_equal(iterated_values, expected_values)
         assert (iterated_feature_ids == expected_feature_ids).all()
 
+    def test_iteration(self, table_biom, metadata):
+        num_chunks = 3
+        chunk_size = 10
+
+        model_iterator = ModelIterator(
+            table=table_biom,
+            model=NegativeBinomialSingle,
+            formula="host_common_name",
+            num_chunks=3,
+            metadata=metadata,
+            num_iter=100,
+            chains=4,
+            seed=42
+        )
+
+        tbl_fids = list(table_biom.ids("observation"))
+        exp_chunk_fids = [
+            tbl_fids[i: i+chunk_size]
+            for i in range(0, table_biom.shape[0], chunk_size)
+        ]
+
+        chunk_sizes = []
+        chunk_fids = []
+        for i, chunk in enumerate(model_iterator):
+            chunk_sizes.append(len(chunk))
+            chunk_fids.append([x[0] for x in chunk])
+
+        chunk_2 = model_iterator[1]
+
+        assert chunk_sizes == [10, 10, 8]
+        assert chunk_fids == exp_chunk_fids
+
+        for (fid, _), exp_fid in zip(chunk_2, exp_chunk_fids[1]):
+            assert fid == exp_fid
+
     def test_iteration_fit(self, table_biom, metadata):
         model_iterator = ModelIterator(
             table=table_biom,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -158,8 +158,7 @@ class TestModelIterator:
         np.testing.assert_equal(iterated_values, expected_values)
         assert (iterated_feature_ids == expected_feature_ids).all()
 
-    def test_iteration(self, table_biom, metadata):
-        num_chunks = 3
+    def test_chunks(self, table_biom, metadata):
         chunk_size = 10
 
         model_iterator = ModelIterator(


### PR DESCRIPTION
Can now specify number of chunks to a model iterator. This should make it easier for users to run e.g. SLURM array jobs and grab the chunk they need.